### PR TITLE
Bump Tested up to WordPress 7.1

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: wpswings
 Donate link: https://wpswings.com/
 Tags: PDF, invoices, 3d flipbook, PDF generator, pdf flipbook, WordPress PDF generator
 Requires at least: 6.7.0
-Tested up to: 7.0
+Tested up to: 7.1
 WC requires at least: 6.5.0
 WC tested up to: 11.0.1
 Stable tag: 1.6.4

--- a/pdf-generator-for-wp.php
+++ b/pdf-generator-for-wp.php
@@ -22,7 +22,7 @@
  * Domain Path:       /languages
  *
  * Requires at least:    6.7.0
- * Tested up to:         7.0
+ * Tested up to:         7.1
  * WC requires at least: 6.5.0
  * WC tested up to:      11.0.1
  * Stable tag:           1.6.4


### PR DESCRIPTION
## Summary

Bumped "Tested up to" in the plugin header and `readme.txt` from 7.0 to 7.1.

## Test Plan

- [x] Verified live against a WordPress 7.1-RC4 install (`get_bloginfo('version')` confirms `7.1-RC4`)
- [x] Ran PHPCompatibilityWP (testVersion 7.4-8.3) — zero issues in the plugin's own code
- [x] Site loads and the plugin activates cleanly on this WP 7.1-RC4 install
