### PR TITLE
Bring plugin code into WordPress Coding Standards compliance

### DIFF
--- a/Elementor/class-elementor-widget-wps-google-elements.php
+++ b/Elementor/class-elementor-widget-wps-google-elements.php
@@ -53,17 +53,17 @@ class Elementor_Widget_WPS_Google_Elements extends Widget_Base {
 			'content_section',
 			array(
 				'label' => __( 'Google Embed Settings', 'pdf-generator-for-wp' ),
-				'tab' => Controls_Manager::TAB_CONTENT,
+				'tab'   => Controls_Manager::TAB_CONTENT,
 			)
 		);
 
 		$this->add_control(
 			'google_url',
 			array(
-				'label' => __( 'Google Service Embed URL', 'pdf-generator-for-wp' ),
-				'type' => Controls_Manager::TEXT,
+				'label'       => __( 'Google Service Embed URL', 'pdf-generator-for-wp' ),
+				'type'        => Controls_Manager::TEXT,
 				'placeholder' => __( 'Paste Google Docs, Sheets, Slides, Forms, etc. URL', 'pdf-generator-for-wp' ),
-				'default' => '',
+				'default'     => '',
 			)
 		);
 
@@ -108,8 +108,8 @@ class Elementor_Widget_WPS_Google_Elements extends Widget_Base {
 			$place = isset( $place_match[1] ) ? str_replace( '+', ' ', $place_match[1] ) : '';
 
 			return 'https://maps.google.com/maps?hl=en&ie=UTF8&ll=' . esc_attr( $lat ) . ',' . esc_attr( $lng ) .
-				   '&spn=' . esc_attr( $lat ) . ',' . esc_attr( $lng ) . '&q=' . esc_attr( $place ) .
-				   '&t=m&z=17&output=embed&iwloc';
+					'&spn=' . esc_attr( $lat ) . ',' . esc_attr( $lng ) . '&q=' . esc_attr( $place ) .
+					'&t=m&z=17&output=embed&iwloc';
 		}
 
 		if ( strpos( $url, 'calendar.google.com/calendar' ) !== false ) {
@@ -127,9 +127,9 @@ class Elementor_Widget_WPS_Google_Elements extends Widget_Base {
 	 * Render the widget output on the frontend.
 	 */
 	protected function render() {
-		$settings   = $this->get_settings_for_display();
-		$url        = $settings['google_url'];
-		$embed_url  = esc_url( $this->get_embed_url( $url ) );
+		$settings  = $this->get_settings_for_display();
+		$url       = $settings['google_url'];
+		$embed_url = esc_url( $this->get_embed_url( $url ) );
 
 		if ( strpos( $url, 'docs.google.com/drawings' ) !== false ) {
 			echo '<img src="' . esc_url( $embed_url ) . '" width="800" height="500" style="border:1px solid #ddd;" />';

--- a/Elementor/class-elementor-widget-wps-linkedin.php
+++ b/Elementor/class-elementor-widget-wps-linkedin.php
@@ -74,9 +74,9 @@ class Elementor_Widget_WPS_LinkedIn extends Widget_Base {
 	 * Render the widget output on the frontend.
 	 */
 	protected function render() {
-		$settings  = $this->get_settings_for_display();
-		$post_id   = isset( $settings['linkedin_post_id'] ) ? trim( $settings['linkedin_post_id'] ) : '';
-		$help_url  = 'https://docs.wpswings.com/pdf-generator-for-wp/?utm_source=wpswings-pdf-doc&utm_medium=referral&utm_campaign=documentation';
+		$settings = $this->get_settings_for_display();
+		$post_id  = isset( $settings['linkedin_post_id'] ) ? trim( $settings['linkedin_post_id'] ) : '';
+		$help_url = 'https://docs.wpswings.com/pdf-generator-for-wp/?utm_source=wpswings-pdf-doc&utm_medium=referral&utm_campaign=documentation';
 
 		if ( ! empty( $post_id ) ) {
 			$embed_url = 'https://www.linkedin.com/embed/feed/update/urn:li:share:' . rawurlencode( $post_id );

--- a/Elementor/class-elementor-widget-wps-loom.php
+++ b/Elementor/class-elementor-widget-wps-loom.php
@@ -73,9 +73,9 @@ class Elementor_Widget_WPS_Loom extends Widget_Base {
 	 * Render widget output on frontend.
 	 */
 	protected function render() {
-		$settings   = $this->get_settings_for_display();
-		$loom_url   = isset( $settings['loom_url'] ) ? trim( $settings['loom_url'] ) : '';
-		$embed_url  = '';
+		$settings  = $this->get_settings_for_display();
+		$loom_url  = isset( $settings['loom_url'] ) ? trim( $settings['loom_url'] ) : '';
+		$embed_url = '';
 
 		if ( preg_match( '/loom\.com\/share\/([a-zA-Z0-9]+)/', $loom_url, $matches ) ) {
 			$embed_url = 'https://www.loom.com/embed/' . esc_attr( $matches[1] );

--- a/Elementor/class-elementor-widget-wps-twitch.php
+++ b/Elementor/class-elementor-widget-wps-twitch.php
@@ -148,19 +148,19 @@ class Elementor_Widget_WPS_Twitch extends Widget_Base {
 	protected function render() {
 		$settings = $this->get_settings_for_display();
 
-		$channel    = sanitize_text_field( $settings['channel'] ?? '' );
-		$width      = sanitize_text_field( $settings['width'] ?? '100%' );
-		$height     = sanitize_text_field( $settings['height'] ?? '480' );
-		$chat_width = sanitize_text_field( $settings['chat_width'] ?? '100%' );
+		$channel     = sanitize_text_field( $settings['channel'] ?? '' );
+		$width       = sanitize_text_field( $settings['width'] ?? '100%' );
+		$height      = sanitize_text_field( $settings['height'] ?? '480' );
+		$chat_width  = sanitize_text_field( $settings['chat_width'] ?? '100%' );
 		$chat_height = sanitize_text_field( $settings['chat_height'] ?? '480' );
-		$show_chat  = $settings['show_chat'] ?? 'yes';
+		$show_chat   = $settings['show_chat'] ?? 'yes';
 
 		if ( '' === $channel ) {
 			echo '<p style="color:red;">' . esc_html__( 'Please provide a Twitch channel name.', 'pdf-generator-for-wp' ) . '</p>';
 			return;
 		}
 
-		$host = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
+		$host   = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
 		$parent = esc_attr( $host );
 
 		echo '<div class="wps-twitch-embed" style="display:flex;flex-wrap:wrap;gap:20px;">';

--- a/admin/class-pdf-generator-for-wp-admin.php
+++ b/admin/class-pdf-generator-for-wp-admin.php
@@ -57,7 +57,7 @@ class Pdf_Generator_For_Wp_Admin {
 	 * @since    1.0.0
 	 * @param    string $hook      The plugin page slug.
 	 */
-	public function pgfw_admin_enqueue_styles( $hook ) {
+	public function pgfw_admin_enqueue_styles( $hook ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- $hook is required by the admin_enqueue_scripts hook signature.
 		$screen = get_current_screen();
 		if ( isset( $screen->id ) && ( 'wp-swings_page_pdf_generator_for_wp_menu' == $screen->id || 'wp-swings_page_home' == $screen->id ) ) { // phpcs:ignore
 
@@ -87,13 +87,13 @@ class Pdf_Generator_For_Wp_Admin {
 	 * @since    1.0.0
 	 * @param    string $hook      The plugin page slug.
 	 */
-	public function pgfw_admin_enqueue_scripts( $hook ) {
+	public function pgfw_admin_enqueue_scripts( $hook ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- $hook is required by the admin_enqueue_scripts hook signature.
 
-		$screen = get_current_screen();
+		$screen         = get_current_screen();
 		$wps_wgm_notice = array(
-			'ajaxurl'       => admin_url( 'admin-ajax.php' ),
-			'wps_pgfw_nonce' => wp_create_nonce( 'wps-pgfw-verify-notice-nonce' ),
-			'check_pro_activate'     => ! wps_pgfw_is_pdf_pro_plugin_active(),
+			'ajaxurl'            => admin_url( 'admin-ajax.php' ),
+			'wps_pgfw_nonce'     => wp_create_nonce( 'wps-pgfw-verify-notice-nonce' ),
+			'check_pro_activate' => ! wps_pgfw_is_pdf_pro_plugin_active(),
 
 		);
 		wp_register_script( $this->plugin_name . 'admin-notice', plugin_dir_url( __FILE__ ) . 'src/js/pdf-generator-for-wp-notices.js', array( 'jquery' ), $this->version, false );
@@ -107,10 +107,10 @@ class Pdf_Generator_For_Wp_Admin {
 			wp_enqueue_script( 'wps-pgfw-metarial-lite', PDF_GENERATOR_FOR_WP_DIR_URL . 'package/lib/material-design/material-lite.min.js', array(), time(), false );
 
 			wp_register_script( $this->plugin_name . 'admin-js', PDF_GENERATOR_FOR_WP_DIR_URL . 'admin/src/js/pdf-generator-for-wp-admin.js', array( 'jquery', 'wps-pgfw-select2', 'wps-pgfw-metarial-js', 'wps-pgfw-metarial-js2', 'wps-pgfw-metarial-lite' ), time(), false );
-			$wps_wpg_plugin_list = get_option( 'active_plugins' );
+			$wps_wpg_plugin_list   = get_option( 'active_plugins' );
 			$wps_wpg_is_pro_active = false;
-			$wps_wpg_plugin = 'wordpress-pdf-generator/wordpress-pdf-generator.php';
-			if ( in_array( $wps_wpg_plugin, $wps_wpg_plugin_list ) ) {
+			$wps_wpg_plugin        = 'wordpress-pdf-generator/wordpress-pdf-generator.php';
+			if ( in_array( $wps_wpg_plugin, $wps_wpg_plugin_list, true ) ) {
 				$wps_wpg_is_pro_active = true;
 			}
 			$license_check = get_option( 'wps_wpg_license_check', 0 );
@@ -122,9 +122,9 @@ class Pdf_Generator_For_Wp_Admin {
 					'ajaxurl'             => admin_url( 'admin-ajax.php' ),
 					'reloadurl'           => admin_url( 'admin.php?page=pdf_generator_for_wp_menu' ),
 					'pgfw_gen_tab_enable' => get_option( 'pgfw_radio_switch_demo' ),
-					'is_pro_active' => $wps_wpg_is_pro_active,
-					'license_check' => $license_check,
-					'nonce'         => wp_create_nonce( 'wps_wpg_embed_ajax_nonce' ),
+					'is_pro_active'       => $wps_wpg_is_pro_active,
+					'license_check'       => $license_check,
+					'nonce'               => wp_create_nonce( 'wps_wpg_embed_ajax_nonce' ),
 				)
 			);
 
@@ -160,20 +160,20 @@ class Pdf_Generator_For_Wp_Admin {
 					'wps-pgfw-admin-custom-setting-js',
 					'pgfw_admin_custom_param',
 					array(
-						'ajaxurl'            => admin_url( 'admin-ajax.php' ),
-						'delete_loader'      => esc_html__( 'Deleting....', 'pdf-generator-for-wp' ),
-						'nonce'              => wp_create_nonce( 'pgfw_delete_media_by_id' ),
-						'pgfw_doc_dummy_img' => PDF_GENERATOR_FOR_WP_DIR_URL . 'admin/src/images/document-management-big.png',
-						'upload_doc'         => esc_html__( 'Upload Doc', 'pdf-generator-for-wp' ),
-						'use_doc'            => esc_html__( 'Use Doc', 'pdf-generator-for-wp' ),
-						'upload_image'       => esc_html__( 'Upload Image', 'pdf-generator-for-wp' ),
+						'ajaxurl'              => admin_url( 'admin-ajax.php' ),
+						'delete_loader'        => esc_html__( 'Deleting....', 'pdf-generator-for-wp' ),
+						'nonce'                => wp_create_nonce( 'pgfw_delete_media_by_id' ),
+						'pgfw_doc_dummy_img'   => PDF_GENERATOR_FOR_WP_DIR_URL . 'admin/src/images/document-management-big.png',
+						'upload_doc'           => esc_html__( 'Upload Doc', 'pdf-generator-for-wp' ),
+						'use_doc'              => esc_html__( 'Use Doc', 'pdf-generator-for-wp' ),
+						'upload_image'         => esc_html__( 'Upload Image', 'pdf-generator-for-wp' ),
 						'upload_invoice_image' => esc_html__( 'Upload Invoice Image', 'pdf-generator-for-wp' ),
-						'use_image'          => esc_html__( 'Use Image', 'pdf-generator-for-wp' ),
-						'confirm_text'       => esc_html__( 'Are you sure you want to delete Doc ?', 'pdf-generator-for-wp' ),
-						'reset_confirm'      => esc_html__( 'Are you sure you want to reset all the settings to default ?', 'pdf-generator-for-wp' ),
-						'reset_loader'       => PDF_GENERATOR_FOR_WP_DIR_URL . 'admin/src/images/loader.gif',
-						'reset_success'      => PDF_GENERATOR_FOR_WP_DIR_URL . 'admin/src/images/checked.png',
-						'reset_error'        => PDF_GENERATOR_FOR_WP_DIR_URL . 'admin/src/images/cross.png',
+						'use_image'            => esc_html__( 'Use Image', 'pdf-generator-for-wp' ),
+						'confirm_text'         => esc_html__( 'Are you sure you want to delete Doc ?', 'pdf-generator-for-wp' ),
+						'reset_confirm'        => esc_html__( 'Are you sure you want to reset all the settings to default ?', 'pdf-generator-for-wp' ),
+						'reset_loader'         => PDF_GENERATOR_FOR_WP_DIR_URL . 'admin/src/images/loader.gif',
+						'reset_success'        => PDF_GENERATOR_FOR_WP_DIR_URL . 'admin/src/images/checked.png',
+						'reset_error'          => PDF_GENERATOR_FOR_WP_DIR_URL . 'admin/src/images/cross.png',
 					)
 				);
 			}
@@ -267,9 +267,9 @@ class Pdf_Generator_For_Wp_Admin {
 			'wps-pgfw-pdf-handler',
 			'wpsGfwPdf',
 			array(
-				'fbFetchNonce' => wp_create_nonce( 'fb_fetch_pdf' ),
+				'fbFetchNonce'  => wp_create_nonce( 'fb_fetch_pdf' ),
 				'fbUploadNonce' => wp_create_nonce( 'ifb_upload_pdf' ),
-				'fbAjaxUrl' => esc_url( admin_url( 'admin-ajax.php' ) ),
+				'fbAjaxUrl'     => esc_url( admin_url( 'admin-ajax.php' ) ),
 			)
 		);
 		wp_enqueue_script( 'flipbook-js', plugin_dir_url( __FILE__ ) . 'src/js/flipbook.js', array( 'jquery' ), '1.0.0', true );
@@ -302,7 +302,7 @@ class Pdf_Generator_For_Wp_Admin {
 	 * @since   1.0.0
 	 */
 	public function wps_pgfw_remove_default_submenu() {
-		 global $submenu;
+		global $submenu;
 		if ( is_array( $submenu ) && array_key_exists( 'wps-plugins', $submenu ) ) {
 			if ( isset( $submenu['wps-plugins'][0] ) ) {
 				unset( $submenu['wps-plugins'][0] );
@@ -355,18 +355,18 @@ class Pdf_Generator_For_Wp_Admin {
 	 * @return array
 	 */
 	public function pgfw_admin_general_settings_page( $pgfw_settings_general_html_arr ) {
-		$general_settings_data     = get_option( 'pgfw_general_settings_save', array() );
-		$pgfw_enable_plugin        = array_key_exists( 'pgfw_enable_plugin', $general_settings_data ) ? $general_settings_data['pgfw_enable_plugin'] : '';
-		$pgfw_show_post_categories = array_key_exists( 'pgfw_general_pdf_show_categories', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_categories'] : '';
-		$pgfw_flipbook_enable = array_key_exists( 'pgfw_flipbook_enable', $general_settings_data ) ? $general_settings_data['pgfw_flipbook_enable'] : '';
-		$pgfw_show_post_tags       = array_key_exists( 'pgfw_general_pdf_show_tags', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_tags'] : '';
-		$pgfw_show_post_taxonomy   = array_key_exists( 'pgfw_general_pdf_show_taxonomy', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_taxonomy'] : '';
-		$pgfw_show_post_date       = array_key_exists( 'pgfw_general_pdf_show_post_date', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_post_date'] : '';
-		$pgfw_show_post_author     = array_key_exists( 'pgfw_general_pdf_show_author_name', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_author_name'] : '';
-		$pgfw_pdf_generate_mode    = array_key_exists( 'pgfw_general_pdf_generate_mode', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_generate_mode'] : '';
-		$pgfw_pdf_file_name        = array_key_exists( 'pgfw_general_pdf_file_name', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_file_name'] : '';
-		$pgfw_pdf_file_name_custom = array_key_exists( 'pgfw_custom_pdf_file_name', $general_settings_data ) ? $general_settings_data['pgfw_custom_pdf_file_name'] : '';
-		$pgfw_general_pdf_date_format    = array_key_exists( 'pgfw_general_pdf_date_format', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_date_format'] : '';
+		$general_settings_data        = get_option( 'pgfw_general_settings_save', array() );
+		$pgfw_enable_plugin           = array_key_exists( 'pgfw_enable_plugin', $general_settings_data ) ? $general_settings_data['pgfw_enable_plugin'] : '';
+		$pgfw_show_post_categories    = array_key_exists( 'pgfw_general_pdf_show_categories', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_categories'] : '';
+		$pgfw_flipbook_enable         = array_key_exists( 'pgfw_flipbook_enable', $general_settings_data ) ? $general_settings_data['pgfw_flipbook_enable'] : '';
+		$pgfw_show_post_tags          = array_key_exists( 'pgfw_general_pdf_show_tags', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_tags'] : '';
+		$pgfw_show_post_taxonomy      = array_key_exists( 'pgfw_general_pdf_show_taxonomy', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_taxonomy'] : '';
+		$pgfw_show_post_date          = array_key_exists( 'pgfw_general_pdf_show_post_date', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_post_date'] : '';
+		$pgfw_show_post_author        = array_key_exists( 'pgfw_general_pdf_show_author_name', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_author_name'] : '';
+		$pgfw_pdf_generate_mode       = array_key_exists( 'pgfw_general_pdf_generate_mode', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_generate_mode'] : '';
+		$pgfw_pdf_file_name           = array_key_exists( 'pgfw_general_pdf_file_name', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_file_name'] : '';
+		$pgfw_pdf_file_name_custom    = array_key_exists( 'pgfw_custom_pdf_file_name', $general_settings_data ) ? $general_settings_data['pgfw_custom_pdf_file_name'] : '';
+		$pgfw_general_pdf_date_format = array_key_exists( 'pgfw_general_pdf_date_format', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_date_format'] : '';
 		$pgfw_show_current_date       = array_key_exists( 'pgfw_general_pdf_show_current_date', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_current_date'] : '';
 		// Get the flipbook URL.
 		$flipbook_url = admin_url( 'edit.php?post_type=flipbook' );
@@ -378,7 +378,7 @@ class Pdf_Generator_For_Wp_Admin {
 		if ( 'yes' === $pgfw_flipbook_enable ) {
 			$description .= ' <a href="' . esc_url( $flipbook_url ) . '">' . __( 'Visit Here', 'pdf-generator-for-wp' ) . '</a>';
 		}
-		$pgfw_settings_general_html_arr   = array(
+		$pgfw_settings_general_html_arr = array(
 			array(
 				'title'       => __( 'Enable Plugin', 'pdf-generator-for-wp' ),
 				'type'        => 'radio-switch',
@@ -483,13 +483,13 @@ class Pdf_Generator_For_Wp_Admin {
 				'name'         => 'pgfw_general_pdf_date_format',
 				'parent-class' => 'wps_pgfw_setting_separate_border',
 				'options'      => array(
-					'Y/m/d' => 'yyyy/mm/dd',
-					'm/d/Y' => 'mm/dd/yyyy',
-					'd M Y' => 'd MM yyyy',
+					'Y/m/d'    => 'yyyy/mm/dd',
+					'm/d/Y'    => 'mm/dd/yyyy',
+					'd M Y'    => 'd MM yyyy',
 					'l, d M Y' => 'DD, d MM yyyy',
-					'Y-m-d' => 'yyyy-mm-dd',
-					'd/m/Y' => 'dd/mm/yyyy',
-					'd.m.Y' => 'd.m.yyyy',
+					'Y-m-d'    => 'yyyy-mm-dd',
+					'd/m/Y'    => 'dd/mm/yyyy',
+					'd.m.Y'    => 'd.m.yyyy',
 				),
 			),
 			array(
@@ -665,8 +665,8 @@ class Pdf_Generator_For_Wp_Admin {
 	 */
 	public function pgfw_admin_display_settings_page( $pgfw_settings_display_fields_html_arr ) {
 		$pgfw_display_settings                   = get_option( 'pgfw_save_admin_display_settings', array() );
-		$pgfw_template_color               = array_key_exists( 'pgfw_template_color', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_color'] : '#FFFFFF';
-		$pgfw_template_text_color       = array_key_exists( 'pgfw_template_text_color', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_text_color'] : '#000000';
+		$pgfw_template_color                     = array_key_exists( 'pgfw_template_color', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_color'] : '#FFFFFF';
+		$pgfw_template_text_color                = array_key_exists( 'pgfw_template_text_color', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_text_color'] : '#000000';
 		$pgfw_user_access                        = array_key_exists( 'pgfw_user_access', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_user_access'] : '';
 		$pgfw_guest_access                       = array_key_exists( 'pgfw_guest_access', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_guest_access'] : '';
 		$pgfw_guest_download_or_email            = array_key_exists( 'pgfw_guest_download_or_email', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_guest_download_or_email'] : '';
@@ -679,17 +679,17 @@ class Pdf_Generator_For_Wp_Admin {
 		$pgfw_body_show_pdf_icon                 = array_key_exists( 'pgfw_body_show_pdf_icon', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_body_show_pdf_icon'] : '';
 		$pgfw_show_post_type_icons_for_user_role = array_key_exists( 'pgfw_show_post_type_icons_for_user_role', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_show_post_type_icons_for_user_role'] : '';
 
-		$pgfw_template_color_option                 = array_key_exists( 'pgfw_template_color_option', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_color_option'] : '';
+		$pgfw_template_color_option = array_key_exists( 'pgfw_template_color_option', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_color_option'] : '';
 
 		global $wp_roles;
-		$all_roles = $wp_roles->roles;
+		$all_roles   = $wp_roles->roles;
 		$roles_array = array();
 
 		foreach ( $all_roles as $role => $value ) {
 
 			$roles_array[ $role ] = $role;
 		}
-		$pgfw_pdf_icon_places              = array(
+		$pgfw_pdf_icon_places = array(
 			''               => __( 'Select option', 'pdf-generator-for-wp' ),
 			'before_content' => __( 'Before Content', 'pdf-generator-for-wp' ),
 			'after_content'  => __( 'After Content', 'pdf-generator-for-wp' ),
@@ -710,7 +710,7 @@ class Pdf_Generator_For_Wp_Admin {
 			}
 		}
 
-		$pgfw_settings_display_fields_html_arr   = array(
+		$pgfw_settings_display_fields_html_arr = array(
 			array(
 				'title'       => __( 'Logged in Users', 'pdf-generator-for-wp' ),
 				'type'        => 'radio-switch',
@@ -852,10 +852,10 @@ class Pdf_Generator_For_Wp_Admin {
 				'class'       => 'pgfw_display_pdf_icon_alignment',
 				'name'        => 'pgfw_display_pdf_icon_alignment',
 				'options'     => array(
-					''       => __( 'Please Choose', 'pdf-generator-for-wp' ),
-					'flex-start'   => __( 'Left', 'pdf-generator-for-wp' ),
-					'center' => __( 'Center', 'pdf-generator-for-wp' ),
-					'flex-end'  => __( 'Right', 'pdf-generator-for-wp' ),
+					''           => __( 'Please Choose', 'pdf-generator-for-wp' ),
+					'flex-start' => __( 'Left', 'pdf-generator-for-wp' ),
+					'center'     => __( 'Center', 'pdf-generator-for-wp' ),
+					'flex-end'   => __( 'Right', 'pdf-generator-for-wp' ),
 				),
 			),
 
@@ -1202,16 +1202,16 @@ class Pdf_Generator_For_Wp_Admin {
 	 * @return array
 	 */
 	public function pgfw_admin_footer_settings_page( $pgfw_settings_footer_fields_html_arr ) {
-		$pgfw_footer_settings   = get_option( 'pgfw_footer_setting_submit', array() );
-		$pgfw_footer_use_in_pdf = array_key_exists( 'pgfw_footer_use_in_pdf', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_use_in_pdf'] : '';
-		$pgfw_footer_tagline    = array_key_exists( 'pgfw_footer_tagline', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_tagline'] : '';
-		$pgfw_footer_color      = array_key_exists( 'pgfw_footer_color', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_color'] : '';
-		$pgfw_footer_width      = array_key_exists( 'pgfw_footer_width', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_width'] : '';
-		$pgfw_footer_font_style = array_key_exists( 'pgfw_footer_font_style', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_font_style'] : '';
-		$pgfw_footer_font_size  = array_key_exists( 'pgfw_footer_font_size', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_font_size'] : '';
-		$pgfw_footer_bottom     = array_key_exists( 'pgfw_footer_bottom', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_bottom'] : '';
-		$pgfw_footer_customization     = array_key_exists( 'pgfw_footer_customization_for_post_detail', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_customization_for_post_detail'] : array();
-		$wps_pgfw_font_styles   = array(
+		$pgfw_footer_settings      = get_option( 'pgfw_footer_setting_submit', array() );
+		$pgfw_footer_use_in_pdf    = array_key_exists( 'pgfw_footer_use_in_pdf', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_use_in_pdf'] : '';
+		$pgfw_footer_tagline       = array_key_exists( 'pgfw_footer_tagline', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_tagline'] : '';
+		$pgfw_footer_color         = array_key_exists( 'pgfw_footer_color', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_color'] : '';
+		$pgfw_footer_width         = array_key_exists( 'pgfw_footer_width', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_width'] : '';
+		$pgfw_footer_font_style    = array_key_exists( 'pgfw_footer_font_style', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_font_style'] : '';
+		$pgfw_footer_font_size     = array_key_exists( 'pgfw_footer_font_size', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_font_size'] : '';
+		$pgfw_footer_bottom        = array_key_exists( 'pgfw_footer_bottom', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_bottom'] : '';
+		$pgfw_footer_customization = array_key_exists( 'pgfw_footer_customization_for_post_detail', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_customization_for_post_detail'] : array();
+		$wps_pgfw_font_styles      = array(
 			''            => __( 'Select option', 'pdf-generator-for-wp' ),
 			'helvetica'   => __( 'Helvetica', 'pdf-generator-for-wp' ),
 			'courier'     => __( 'Courier', 'pdf-generator-for-wp' ),
@@ -1221,9 +1221,9 @@ class Pdf_Generator_For_Wp_Admin {
 			'symbol'      => __( 'Symbol', 'pdf-generator-for-wp' ),
 			'zapfdinbats' => __( 'Zapfdinbats', 'pdf-generator-for-wp' ),
 		);
-		$wps_pgfw_font_styles   = apply_filters( 'wps_pgfw_font_styles_filter_hook', $wps_pgfw_font_styles );
+		$wps_pgfw_font_styles      = apply_filters( 'wps_pgfw_font_styles_filter_hook', $wps_pgfw_font_styles );
 
-		$pgfw_settings_footer_fields_html_arr   = array(
+		$pgfw_settings_footer_fields_html_arr = array(
 			array(
 				'title'       => __( 'Include Footer', 'pdf-generator-for-wp' ),
 				'type'        => 'checkbox',
@@ -1308,9 +1308,9 @@ class Pdf_Generator_For_Wp_Admin {
 				'class'       => 'pgfw-multiselect-class wps-defaut-multiselect pgfw_advanced_show_post_type_icons',
 				'name'        => 'pgfw_footer_customization_for_post_detail',
 				'options'     => array(
-					'author' => __( 'author name', 'pdf-generator-for-wp' ),
-					'post_title'      => __( 'post title', 'pdf-generator-for-wp' ),
-					'post_date'      => __( 'publish date', 'pdf-generator-for-wp' ),
+					'author'     => __( 'author name', 'pdf-generator-for-wp' ),
+					'post_title' => __( 'post title', 'pdf-generator-for-wp' ),
+					'post_date'  => __( 'publish date', 'pdf-generator-for-wp' ),
 				),
 			),
 		);
@@ -1374,38 +1374,38 @@ class Pdf_Generator_For_Wp_Admin {
 	 * @return array
 	 */
 	public function pgfw_admin_body_settings_page( $pgfw_body_html_arr ) {
-		$pgfw_body_settings          = get_option( 'pgfw_body_save_settings', array() );
-		$pgfw_body_title_font_style  = array_key_exists( 'pgfw_body_title_font_style', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_title_font_style'] : '';
-		$pgfw_body_title_font_size   = array_key_exists( 'pgfw_body_title_font_size', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_title_font_size'] : '';
-		$pgfw_body_title_font_color  = array_key_exists( 'pgfw_body_title_font_color', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_title_font_color'] : '';
-		$pgfw_body_page_size         = array_key_exists( 'pgfw_body_page_size', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_page_size'] : '';
-		$pgfw_body_page_orientation  = array_key_exists( 'pgfw_body_page_orientation', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_page_orientation'] : '';
-		$pgfw_body_page_font_style   = array_key_exists( 'pgfw_body_page_font_style', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_page_font_style'] : '';
-		$pgfw_body_page_font_size    = array_key_exists( 'pgfw_content_font_size', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_content_font_size'] : '';
-		$pgfw_body_page_font_color   = array_key_exists( 'pgfw_body_font_color', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_font_color'] : '';
-		$pgfw_body_border_size       = array_key_exists( 'pgfw_body_border_size', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_border_size'] : '';
-		$pgfw_body_border_color      = array_key_exists( 'pgfw_body_border_color', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_border_color'] : '';
-		$pgfw_body_margin_top        = array_key_exists( 'pgfw_body_margin_top', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_margin_top'] : '';
-		$pgfw_body_margin_left       = array_key_exists( 'pgfw_body_margin_left', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_margin_left'] : '';
-		$pgfw_body_margin_right      = array_key_exists( 'pgfw_body_margin_right', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_margin_right'] : '';
-		$pgfw_body_margin_bottom     = array_key_exists( 'pgfw_body_margin_bottom', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_margin_bottom'] : '';
-		$pgfw_body_rtl_support       = array_key_exists( 'pgfw_body_rtl_support', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_rtl_support'] : '';
-		$pgfw_body_add_watermark     = array_key_exists( 'pgfw_body_add_watermark', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_add_watermark'] : '';
+		$pgfw_body_settings                = get_option( 'pgfw_body_save_settings', array() );
+		$pgfw_body_title_font_style        = array_key_exists( 'pgfw_body_title_font_style', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_title_font_style'] : '';
+		$pgfw_body_title_font_size         = array_key_exists( 'pgfw_body_title_font_size', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_title_font_size'] : '';
+		$pgfw_body_title_font_color        = array_key_exists( 'pgfw_body_title_font_color', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_title_font_color'] : '';
+		$pgfw_body_page_size               = array_key_exists( 'pgfw_body_page_size', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_page_size'] : '';
+		$pgfw_body_page_orientation        = array_key_exists( 'pgfw_body_page_orientation', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_page_orientation'] : '';
+		$pgfw_body_page_font_style         = array_key_exists( 'pgfw_body_page_font_style', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_page_font_style'] : '';
+		$pgfw_body_page_font_size          = array_key_exists( 'pgfw_content_font_size', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_content_font_size'] : '';
+		$pgfw_body_page_font_color         = array_key_exists( 'pgfw_body_font_color', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_font_color'] : '';
+		$pgfw_body_border_size             = array_key_exists( 'pgfw_body_border_size', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_border_size'] : '';
+		$pgfw_body_border_color            = array_key_exists( 'pgfw_body_border_color', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_border_color'] : '';
+		$pgfw_body_margin_top              = array_key_exists( 'pgfw_body_margin_top', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_margin_top'] : '';
+		$pgfw_body_margin_left             = array_key_exists( 'pgfw_body_margin_left', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_margin_left'] : '';
+		$pgfw_body_margin_right            = array_key_exists( 'pgfw_body_margin_right', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_margin_right'] : '';
+		$pgfw_body_margin_bottom           = array_key_exists( 'pgfw_body_margin_bottom', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_margin_bottom'] : '';
+		$pgfw_body_rtl_support             = array_key_exists( 'pgfw_body_rtl_support', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_rtl_support'] : '';
+		$pgfw_body_add_watermark           = array_key_exists( 'pgfw_body_add_watermark', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_add_watermark'] : '';
 		$pgfw_body_metafields_row_wise     = array_key_exists( 'pgfw_body_metafields_row_wise', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_metafields_row_wise'] : '';
-		$pgfw_body_images_row_wise     = array_key_exists( 'pgfw_body_images_row_wise', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_images_row_wise'] : '';
-		$pgfw_body_watermark_text    = array_key_exists( 'pgfw_body_watermark_text', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_watermark_text'] : '';
-		$pgfw_body_watermark_color   = array_key_exists( 'pgfw_body_watermark_color', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_watermark_color'] : '';
-		$pgfw_body_page_template     = array_key_exists( 'pgfw_body_page_template', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_page_template'] : '';
-		$pgfw_body_post_template     = array_key_exists( 'pgfw_body_post_template', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_post_template'] : '';
-		$pgfw_body_meta_field_column     = array_key_exists( 'pgfw_body_meta_field_column', $pgfw_body_settings ) ? intval( $pgfw_body_settings['pgfw_body_meta_field_column'] ) : '';
-		$pgfw_border_position_top    = array_key_exists( 'pgfw_border_position_top', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_border_position_top'] : '';
-		$pgfw_border_position_bottom = array_key_exists( 'pgfw_border_position_bottom', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_border_position_bottom'] : '';
-		$pgfw_border_position_left   = array_key_exists( 'pgfw_border_position_left', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_border_position_left'] : '';
-		$pgfw_border_position_right  = array_key_exists( 'pgfw_border_position_right', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_border_position_right'] : '';
-		$pgfw_body_custom_css        = array_key_exists( 'pgfw_body_custom_css', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_custom_css'] : '';
-		$pgfw_body_custom_page_size_height        = array_key_exists( 'pgfw_body_custom_page_size_height', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_custom_page_size_height'] : 150;
-		$pgfw_body_custom_page_size_width        = array_key_exists( 'pgfw_body_custom_page_size_width', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_custom_page_size_width'] : 150;
-		$pgfw_body_customization                 = array_key_exists( 'pgfw_body_customization_for_post_detail', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_customization_for_post_detail'] : array();
+		$pgfw_body_images_row_wise         = array_key_exists( 'pgfw_body_images_row_wise', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_images_row_wise'] : '';
+		$pgfw_body_watermark_text          = array_key_exists( 'pgfw_body_watermark_text', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_watermark_text'] : '';
+		$pgfw_body_watermark_color         = array_key_exists( 'pgfw_body_watermark_color', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_watermark_color'] : '';
+		$pgfw_body_page_template           = array_key_exists( 'pgfw_body_page_template', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_page_template'] : '';
+		$pgfw_body_post_template           = array_key_exists( 'pgfw_body_post_template', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_post_template'] : '';
+		$pgfw_body_meta_field_column       = array_key_exists( 'pgfw_body_meta_field_column', $pgfw_body_settings ) ? intval( $pgfw_body_settings['pgfw_body_meta_field_column'] ) : '';
+		$pgfw_border_position_top          = array_key_exists( 'pgfw_border_position_top', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_border_position_top'] : '';
+		$pgfw_border_position_bottom       = array_key_exists( 'pgfw_border_position_bottom', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_border_position_bottom'] : '';
+		$pgfw_border_position_left         = array_key_exists( 'pgfw_border_position_left', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_border_position_left'] : '';
+		$pgfw_border_position_right        = array_key_exists( 'pgfw_border_position_right', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_border_position_right'] : '';
+		$pgfw_body_custom_css              = array_key_exists( 'pgfw_body_custom_css', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_custom_css'] : '';
+		$pgfw_body_custom_page_size_height = array_key_exists( 'pgfw_body_custom_page_size_height', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_custom_page_size_height'] : 150;
+		$pgfw_body_custom_page_size_width  = array_key_exists( 'pgfw_body_custom_page_size_width', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_custom_page_size_width'] : 150;
+		$pgfw_body_customization           = array_key_exists( 'pgfw_body_customization_for_post_detail', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_customization_for_post_detail'] : array();
 		$pgfw_body_spcl_char_support       = array_key_exists( 'pgfw_body_spcl_char_support', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_spcl_char_support'] : '';
 
 		$wps_pgfw_font_styles = array(
@@ -1419,7 +1419,7 @@ class Pdf_Generator_For_Wp_Admin {
 			'zapfdinbats' => __( 'Zapfdinbats', 'pdf-generator-for-wp' ),
 		);
 
-		$wps_pgfw_font_styles = apply_filters( 'wps_pgfw_font_styles_filter_hook', $wps_pgfw_font_styles );
+		$wps_pgfw_font_styles      = apply_filters( 'wps_pgfw_font_styles_filter_hook', $wps_pgfw_font_styles );
 		$wps_pgfw_custom_page_size = array(
 			''                         => __( 'Select option', 'pdf-generator-for-wp' ),
 			'4a0'                      => __( '4A0', 'pdf-generator-for-wp' ),
@@ -1469,7 +1469,7 @@ class Pdf_Generator_For_Wp_Admin {
 		);
 		$wps_pgfw_custom_page_size = apply_filters( 'wps_pgfw_custom_page_size_filter_hook', $wps_pgfw_custom_page_size );
 
-		$pgfw_body_html_arr   = array(
+		$pgfw_body_html_arr = array(
 			array(
 				'title'       => __( 'Title Font Style', 'pdf-generator-for-wp' ),
 				'type'        => 'select',
@@ -1941,10 +1941,10 @@ class Pdf_Generator_For_Wp_Admin {
 				'class'       => 'pgfw_body_meta_field_column',
 				'name'        => 'pgfw_body_meta_field_column',
 				'options'     => array(
-					'1'          => __( '1', 'pdf-generator-for-wp' ),
-					'2'          => __( '2', 'pdf-generator-for-wp' ),
-					'3'          => __( '3', 'pdf-generator-for-wp' ),
-					'4'          => __( '4', 'pdf-generator-for-wp' ),
+					'1' => __( '1', 'pdf-generator-for-wp' ),
+					'2' => __( '2', 'pdf-generator-for-wp' ),
+					'3' => __( '3', 'pdf-generator-for-wp' ),
+					'4' => __( '4', 'pdf-generator-for-wp' ),
 				),
 			),
 			array(
@@ -1956,9 +1956,9 @@ class Pdf_Generator_For_Wp_Admin {
 				'class'       => 'pgfw-multiselect-class wps-defaut-multiselect pgfw_advanced_show_post_type_icons',
 				'name'        => 'pgfw_body_customization_for_post_detail',
 				'options'     => array(
-					'title' => __( 'Post title', 'pdf-generator-for-wp' ),
-					'post_thumb'      => __( 'Post thumbnail', 'pdf-generator-for-wp' ),
-					'description'      => __( 'Post description', 'pdf-generator-for-wp' ),
+					'title'       => __( 'Post title', 'pdf-generator-for-wp' ),
+					'post_thumb'  => __( 'Post thumbnail', 'pdf-generator-for-wp' ),
+					'description' => __( 'Post description', 'pdf-generator-for-wp' ),
 				),
 			),
 		);
@@ -1984,7 +1984,7 @@ class Pdf_Generator_For_Wp_Admin {
 		$pgfw_advanced_settings  = get_option( 'pgfw_advanced_save_settings', array() );
 		$pgfw_advanced_icon_show = array_key_exists( 'pgfw_advanced_show_post_type_icons', $pgfw_advanced_settings ) ? $pgfw_advanced_settings['pgfw_advanced_show_post_type_icons'] : '';
 
-		$post_types              = get_post_types( array( 'public' => true ) );
+		$post_types = get_post_types( array( 'public' => true ) );
 		unset( $post_types['attachment'] );
 
 		$pgfw_advanced_settings_html_arr   = array();
@@ -2073,12 +2073,12 @@ class Pdf_Generator_For_Wp_Admin {
 			foreach ( $post_meta_fields as $key => $val ) {
 				$post_meta_field[ $val ] = $val;
 			}
-			$pgfw_show_type_meta_val = array_key_exists( 'pgfw_meta_fields_' . $post_type . '_show', $pgfw_meta_settings ) ? $pgfw_meta_settings[ 'pgfw_meta_fields_' . $post_type . '_show' ] : '';
-			$pgfw_show_type_meta_arr = array_key_exists( 'pgfw_meta_fields_' . $post_type . '_list', $pgfw_meta_settings ) ? $pgfw_meta_settings[ 'pgfw_meta_fields_' . $post_type . '_list' ] : array();
-			$pgfw_meta_fields_show_image_gallery = array_key_exists( 'pgfw_meta_fields_show_image_gallery', $pgfw_meta_settings ) ? $pgfw_meta_settings['pgfw_meta_fields_show_image_gallery'] : '';
+			$pgfw_show_type_meta_val                    = array_key_exists( 'pgfw_meta_fields_' . $post_type . '_show', $pgfw_meta_settings ) ? $pgfw_meta_settings[ 'pgfw_meta_fields_' . $post_type . '_show' ] : '';
+			$pgfw_show_type_meta_arr                    = array_key_exists( 'pgfw_meta_fields_' . $post_type . '_list', $pgfw_meta_settings ) ? $pgfw_meta_settings[ 'pgfw_meta_fields_' . $post_type . '_list' ] : array();
+			$pgfw_meta_fields_show_image_gallery        = array_key_exists( 'pgfw_meta_fields_show_image_gallery', $pgfw_meta_settings ) ? $pgfw_meta_settings['pgfw_meta_fields_show_image_gallery'] : '';
 			$pgfw_meta_fields_show_unknown_image_format = array_key_exists( 'pgfw_meta_fields_show_unknown_image_format', $pgfw_meta_settings ) ? $pgfw_meta_settings['pgfw_meta_fields_show_unknown_image_format'] : '';
-			$pgfw_gallery_metafield_key = array_key_exists( 'pgfw_gallery_metafield_key', $pgfw_meta_settings ) ? $pgfw_meta_settings['pgfw_gallery_metafield_key'] : '';
-			$pgfw_meta_settings_html_arr[] =
+			$pgfw_gallery_metafield_key                 = array_key_exists( 'pgfw_gallery_metafield_key', $pgfw_meta_settings ) ? $pgfw_meta_settings['pgfw_gallery_metafield_key'] : '';
+			$pgfw_meta_settings_html_arr[]              =
 				array(
 					'title'        => __( 'Show Meta Fields For ', 'pdf-generator-for-wp' ) . $post_type,
 					'type'         => 'checkbox',
@@ -2089,7 +2089,7 @@ class Pdf_Generator_For_Wp_Admin {
 					'name'         => 'pgfw_meta_fields_' . $post_type . '_show',
 					'parent-class' => ( 0 === $i ) ? '' : 'wps_pgfw_setting_separate_border',
 				);
-			$pgfw_meta_settings_html_arr[] = array(
+			$pgfw_meta_settings_html_arr[]              = array(
 				'title'       => __( 'Meta Fields in ', 'pdf-generator-for-wp' ) . $post_type,
 				'type'        => 'multiselect',
 				'description' => __( 'These meta fields will be shown on PDF.', 'pdf-generator-for-wp' ),
@@ -2100,29 +2100,29 @@ class Pdf_Generator_For_Wp_Admin {
 				'placeholder' => '',
 				'options'     => $post_meta_field,
 			);
-			$pgfw_meta_settings_html_arr   = apply_filters( 'pgfw_settings_meta_fields_html_arr_filter_hook', $pgfw_meta_settings_html_arr, $post_meta_field, $post_type );
-			$i++;
+			$pgfw_meta_settings_html_arr                = apply_filters( 'pgfw_settings_meta_fields_html_arr_filter_hook', $pgfw_meta_settings_html_arr, $post_meta_field, $post_type );
+			++$i;
 		}
 		$pgfw_meta_settings_html_arr[] =
 			array(
-				'title'        => __( 'Show Product Gallery Image  ', 'pdf-generator-for-wp' ),
-				'type'         => 'checkbox',
-				'description'  => __( 'If your gallery image meta field is different from "_product_image_gallery" then please write the name in below box and enable this setting and uncheck this in metafield section.', 'pdf-generator-for-wp' ),
-				'id'           => 'pgfw_meta_fields_show_image_gallery',
-				'value'        => $pgfw_meta_fields_show_image_gallery,
-				'class'        => 'pgfw_meta_fields_show_image_gallery',
-				'name'         => 'pgfw_meta_fields_show_image_gallery',
+				'title'       => __( 'Show Product Gallery Image  ', 'pdf-generator-for-wp' ),
+				'type'        => 'checkbox',
+				'description' => __( 'If your gallery image meta field is different from "_product_image_gallery" then please write the name in below box and enable this setting and uncheck this in metafield section.', 'pdf-generator-for-wp' ),
+				'id'          => 'pgfw_meta_fields_show_image_gallery',
+				'value'       => $pgfw_meta_fields_show_image_gallery,
+				'class'       => 'pgfw_meta_fields_show_image_gallery',
+				'name'        => 'pgfw_meta_fields_show_image_gallery',
 
 			);
 		$pgfw_meta_settings_html_arr[] =
 			array(
-				'title'        => __( 'Unknown Image Format Handler ', 'pdf-generator-for-wp' ),
-				'type'         => 'checkbox',
-				'description'  => __( 'If your image type is unknown or not rendering in the PDF, please enable this setting.', 'pdf-generator-for-wp' ),
-				'id'           => 'pgfw_meta_fields_show_unknown_image_format',
-				'value'        => $pgfw_meta_fields_show_unknown_image_format,
-				'class'        => 'pgfw_meta_fields_show_unknown_image_format',
-				'name'         => 'pgfw_meta_fields_show_unknown_image_format',
+				'title'       => __( 'Unknown Image Format Handler ', 'pdf-generator-for-wp' ),
+				'type'        => 'checkbox',
+				'description' => __( 'If your image type is unknown or not rendering in the PDF, please enable this setting.', 'pdf-generator-for-wp' ),
+				'id'          => 'pgfw_meta_fields_show_unknown_image_format',
+				'value'       => $pgfw_meta_fields_show_unknown_image_format,
+				'class'       => 'pgfw_meta_fields_show_unknown_image_format',
+				'name'        => 'pgfw_meta_fields_show_unknown_image_format',
 
 			);
 		$pgfw_meta_settings_html_arr[] = array(
@@ -2263,7 +2263,7 @@ class Pdf_Generator_For_Wp_Admin {
 	 * @return void
 	 */
 	public function pgfw_delete_pdf_from_server() {
-		 $upload_dir   = wp_upload_dir();
+		$upload_dir   = wp_upload_dir();
 		$pgfw_pdf_dir = $upload_dir['basedir'] . '/post_to_pdf/';
 		if ( is_dir( $pgfw_pdf_dir ) ) {
 			$files = glob( $pgfw_pdf_dir . '*' );
@@ -2281,7 +2281,7 @@ class Pdf_Generator_For_Wp_Admin {
 	 * @return void
 	 */
 	public function pgfw_reset_default_settings() {
-		 check_ajax_referer( 'pgfw_delete_media_by_id', 'nonce' );
+		check_ajax_referer( 'pgfw_delete_media_by_id', 'nonce' );
 		$this->pgfw_default_settings_update();
 		wp_die();
 	}
@@ -2397,12 +2397,12 @@ class Pdf_Generator_For_Wp_Admin {
 		$result        = array();
 		foreach ( $option_result as $option_key => $option_value ) {
 
-			if ( ( similar_text( 'mwb_pgfw_onboarding_data_skipped', $option_key ) == 32 ) || ( similar_text( 'mwb_all_plugins_active', $option_key ) == 22 ) || ( similar_text( 'mwb_pgfw_onboarding_data_sent', $option_key ) == 29 )
-				|| ( similar_text( 'mwb_wpg_check_license_daily', $option_key ) == 27 )
-				|| ( similar_text( 'mwb_wpg_activated_timestamp', $option_key ) == 27 ) || ( similar_text( 'mwb_wpg_plugin_update', $option_key ) == 21 )
-				|| ( similar_text( 'mwb_wpg_license_key', $option_key ) == 19 ) || ( similar_text( 'mwb_wpg_license_check', $option_key ) == 21 )
-				|| ( similar_text( 'mwb_wpg_meta_fields_in_page', $option_key ) == 27 ) || ( similar_text( 'mwb_wpg_meta_fields_in_post', $option_key ) == 27 )
-				|| ( similar_text( 'mwb_wpg_meta_fields_in_product', $option_key ) == 30 )
+			if ( ( similar_text( 'mwb_pgfw_onboarding_data_skipped', $option_key ) === 32 ) || ( similar_text( 'mwb_all_plugins_active', $option_key ) === 22 ) || ( similar_text( 'mwb_pgfw_onboarding_data_sent', $option_key ) === 29 )
+				|| ( similar_text( 'mwb_wpg_check_license_daily', $option_key ) === 27 )
+				|| ( similar_text( 'mwb_wpg_activated_timestamp', $option_key ) === 27 ) || ( similar_text( 'mwb_wpg_plugin_update', $option_key ) === 21 )
+				|| ( similar_text( 'mwb_wpg_license_key', $option_key ) === 19 ) || ( similar_text( 'mwb_wpg_license_check', $option_key ) === 21 )
+				|| ( similar_text( 'mwb_wpg_meta_fields_in_page', $option_key ) === 27 ) || ( similar_text( 'mwb_wpg_meta_fields_in_post', $option_key ) === 27 )
+				|| ( similar_text( 'mwb_wpg_meta_fields_in_product', $option_key ) === 30 )
 			) {
 
 				$array_val = array(
@@ -2450,19 +2450,19 @@ class Pdf_Generator_For_Wp_Admin {
 			'mwb_pgfw_onboarding_data_skipped' => '',
 			'mwb_all_plugins_active'           => '',
 			'mwb_pgfw_onboarding_data_sent'    => '',
-			'mwb_wpg_check_license_daily' => '',
-			'mwb_wpg_activated_timestamp' => '',
-			'mwb_wpg_plugin_update'       => '',
-			'mwb_wpg_license_key'        => '',
-			'mwb_wpg_license_check'       => '',
-			'mwb_wpg_meta_fields_in_page' => '',
-			'mwb_wpg_meta_fields_in_post' => '',
-			'mwb_wpg_meta_fields_in_product' => '',
+			'mwb_wpg_check_license_daily'      => '',
+			'mwb_wpg_activated_timestamp'      => '',
+			'mwb_wpg_plugin_update'            => '',
+			'mwb_wpg_license_key'              => '',
+			'mwb_wpg_license_check'            => '',
+			'mwb_wpg_meta_fields_in_page'      => '',
+			'mwb_wpg_meta_fields_in_post'      => '',
+			'mwb_wpg_meta_fields_in_product'   => '',
 		);
 
 		foreach ( $wp_options as $key => $value ) {
 
-			$new_key = str_replace( 'mwb_', 'wps_', $key );
+			$new_key   = str_replace( 'mwb_', 'wps_', $key );
 			$new_value = get_option( $key, $value );
 
 			$arr_val = array();
@@ -2471,8 +2471,8 @@ class Pdf_Generator_For_Wp_Admin {
 					$new_key1 = str_replace( 'mwb_', 'wps_', $keys );
 					$new_key2 = str_replace( 'mwb-', 'wps-', $new_key1 );
 
-					$value_1 = str_replace( 'mwb-', 'wps-', $values );
-					$value_2 = str_replace( 'mwb_', 'wps_', $value_1 );
+					$value_1              = str_replace( 'mwb-', 'wps-', $values );
+					$value_2              = str_replace( 'mwb_', 'wps_', $value_1 );
 					$arr_val[ $new_key2 ] = $value_2;
 				}
 
@@ -2528,7 +2528,7 @@ class Pdf_Generator_For_Wp_Admin {
 		$pgfw_taxonomy_settings = get_option( 'pgfw_taxonomy_fields_save_settings', array() );
 
 		$pgfw_taxonomy_settings_arr = array();
-		$post_types                = get_post_types( array( 'public' => true ) );
+		$post_types                 = get_post_types( array( 'public' => true ) );
 		unset( $post_types['attachment'] );
 		$i = 0;
 		foreach ( $post_types as $post_type ) {
@@ -2575,7 +2575,7 @@ class Pdf_Generator_For_Wp_Admin {
 					'value' => $pgfw_taxonomy_settings_sub_arr,
 				);
 			}
-			$i++;
+			++$i;
 		}
 		$pgfw_taxonomy_settings_arr[] = array(
 			'type'        => 'button',
@@ -2612,21 +2612,21 @@ class Pdf_Generator_For_Wp_Admin {
 	 * @return array
 	 */
 	public function pgfw_template_pdf_settings_page_dummy( $pgfw_template_pdf_settings ) {
-		if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
+		if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true ) ) {
 
 			$order_stat = wc_get_order_statuses();
 		} else {
 
 			$order_stat = array();
 		}
-		$temp       = array(
+		$temp                              = array(
 			'wc-never' => __( 'Never', 'pdf-generator-for-wp' ),
 		);
 		$sub_pgfw_pdf_single_download_icon = '';
 		// appending the default value.
 		$order_statuses = is_array( $order_stat ) ? $temp + $order_stat : $temp;
 		// array of html for pdf setting fields.
-		$pgfw_template_pdf_settings   = array(
+		$pgfw_template_pdf_settings = array(
 			array(
 				'title'       => __( 'Enable Invoice Feature', 'pdf-generator-for-wp' ),
 				'type'        => 'radio-switch',
@@ -2677,17 +2677,17 @@ class Pdf_Generator_For_Wp_Admin {
 				'name'        => 'wpg_generate_invoice_from_cache',
 			),
 			array(
-				'title' => __( 'How Do You Want To View PDF?', 'pdf-generator-for-wp' ),
-				'type'  => 'select',
-				'description'  => __( 'Choose if You want to  view in new tab or you want to download.', 'pdf-generator-for-wp' ),
-				'id'    => 'wpg_view_pdf',
-				'name' => 'wpg_view_pdf',
-				'value' => get_option( 'wpg_view_pdf' ),
-				'class' => 'wps_pgfw_pro_tag',
+				'title'       => __( 'How Do You Want To View PDF?', 'pdf-generator-for-wp' ),
+				'type'        => 'select',
+				'description' => __( 'Choose if You want to  view in new tab or you want to download.', 'pdf-generator-for-wp' ),
+				'id'          => 'wpg_view_pdf',
+				'name'        => 'wpg_view_pdf',
+				'value'       => get_option( 'wpg_view_pdf' ),
+				'class'       => 'wps_pgfw_pro_tag',
 				'placeholder' => __( 'Select', 'pdf-generator-for-wp' ),
-				'options' => array(
-					'' => __( 'Select option', 'pdf-generator-for-wp' ),
-					'view' => __( 'View in new tab', 'pdf-generator-for-wp' ),
+				'options'     => array(
+					''         => __( 'Select option', 'pdf-generator-for-wp' ),
+					'view'     => __( 'View in new tab', 'pdf-generator-for-wp' ),
 					'download' => __( 'Download', 'pdf-generator-for-wp' ),
 				),
 			),
@@ -2713,8 +2713,8 @@ class Pdf_Generator_For_Wp_Admin {
 	 */
 	public function pgfw_template_invoice_setting_html_fields_dummy( $invoice_settings_arr ) {
 		$sub_wpg_upload_invoice_company_logo = get_option( 'sub_wpg_upload_invoice_company_logo' );
-		$pgfw_invoice_number_renew_month      = get_option( 'wpg_invoice_number_renew_month' );
-		$pgfw_months                          = array(
+		$pgfw_invoice_number_renew_month     = get_option( 'wpg_invoice_number_renew_month' );
+		$pgfw_months                         = array(
 			'never' => __( 'Never', 'pdf-generator-for-wp' ),
 			1       => __( 'January', 'pdf-generator-for-wp' ),
 			2       => __( 'February', 'pdf-generator-for-wp' ),
@@ -2832,8 +2832,8 @@ class Pdf_Generator_For_Wp_Admin {
 						'value'       => get_option( 'wpg_invoice_number_digit' ),
 						'name'        => 'wpg_invoice_number_digit',
 						'placeholder' => __( 'digit', 'pdf-generator-for-wp' ),
-						'min' => 0,
-						'max' => 3000,
+						'min'         => 0,
+						'max'         => 3000,
 					),
 					array(
 						'title'       => __( 'Suffix', 'pdf-generator-for-wp' ),
@@ -2988,16 +2988,16 @@ class Pdf_Generator_For_Wp_Admin {
 	 */
 	public function pgfw_cover_page_html_layout_fields_dummy( $cover_page_html_arr ) {
 		$pgfw_coverpage_settings_data = get_option( 'pgfw_coverpage_setting_save', array() );
-		$coverpage_single_enable     = array_key_exists( 'pgfw_cover_page_single_enable', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_single_enable'] : '';
-		$coverpage_bulk_enable       = array_key_exists( 'pgfw_cover_page_bulk_enable', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_bulk_enable'] : '';
-		$coverpage_company_name      = array_key_exists( 'pgfw_cover_page_company_name', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_company_name'] : '';
-		$coverpage_company_tagline   = array_key_exists( 'pgfw_cover_page_company_tagline', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_company_tagline'] : '';
-		$coverpage_company_email     = array_key_exists( 'pgfw_cover_page_company_email', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_company_email'] : '';
-		$coverpage_company_address   = array_key_exists( 'pgfw_cover_page_company_address', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_company_address'] : '';
-		$coverpage_company_url       = array_key_exists( 'pgfw_cover_page_company_url', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_company_url'] : '';
-		$cover_page_image            = array_key_exists( 'sub_pgfw_cover_page_image_upload', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['sub_pgfw_cover_page_image_upload'] : '';
-		$cover_page_company_logo     = array_key_exists( 'sub_pgfw_cover_page_company_logo_upload', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['sub_pgfw_cover_page_company_logo_upload'] : '';
-		$coverpage_company_phone     = array_key_exists( 'pgfw_cover_page_company_Phone', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_company_Phone'] : '';
+		$coverpage_single_enable      = array_key_exists( 'pgfw_cover_page_single_enable', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_single_enable'] : '';
+		$coverpage_bulk_enable        = array_key_exists( 'pgfw_cover_page_bulk_enable', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_bulk_enable'] : '';
+		$coverpage_company_name       = array_key_exists( 'pgfw_cover_page_company_name', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_company_name'] : '';
+		$coverpage_company_tagline    = array_key_exists( 'pgfw_cover_page_company_tagline', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_company_tagline'] : '';
+		$coverpage_company_email      = array_key_exists( 'pgfw_cover_page_company_email', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_company_email'] : '';
+		$coverpage_company_address    = array_key_exists( 'pgfw_cover_page_company_address', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_company_address'] : '';
+		$coverpage_company_url        = array_key_exists( 'pgfw_cover_page_company_url', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_company_url'] : '';
+		$cover_page_image             = array_key_exists( 'sub_pgfw_cover_page_image_upload', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['sub_pgfw_cover_page_image_upload'] : '';
+		$cover_page_company_logo      = array_key_exists( 'sub_pgfw_cover_page_company_logo_upload', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['sub_pgfw_cover_page_company_logo_upload'] : '';
+		$coverpage_company_phone      = array_key_exists( 'pgfw_cover_page_company_Phone', $pgfw_coverpage_settings_data ) ? $pgfw_coverpage_settings_data['pgfw_cover_page_company_Phone'] : '';
 
 		$cover_page_html_arr = array(
 			array(
@@ -3173,14 +3173,14 @@ class Pdf_Generator_For_Wp_Admin {
 	public function wps_pgfw_save_notice_message() {
 		$wps_notification_data = $this->wps_pgfw_get_update_notification_data();
 		if ( is_array( $wps_notification_data ) && ! empty( $wps_notification_data ) ) {
-			$banner_id      = array_key_exists( 'notification_id', $wps_notification_data[0] ) ? $wps_notification_data[0]['wps_banner_id'] : '';
+			$banner_id    = array_key_exists( 'notification_id', $wps_notification_data[0] ) ? $wps_notification_data[0]['wps_banner_id'] : '';
 			$banner_image = array_key_exists( 'notification_message', $wps_notification_data[0] ) ? $wps_notification_data[0]['wps_banner_image'] : '';
-			$banner_url = array_key_exists( 'notification_message', $wps_notification_data[0] ) ? $wps_notification_data[0]['wps_banner_url'] : '';
-			$banner_type = array_key_exists( 'notification_message', $wps_notification_data[0] ) ? $wps_notification_data[0]['wps_banner_type'] : '';
+			$banner_url   = array_key_exists( 'notification_message', $wps_notification_data[0] ) ? $wps_notification_data[0]['wps_banner_url'] : '';
+			$banner_type  = array_key_exists( 'notification_message', $wps_notification_data[0] ) ? $wps_notification_data[0]['wps_banner_type'] : '';
 			update_option( 'wps_wgm_notify_new_banner_id', $banner_id );
 			update_option( 'wps_wgm_notify_new_banner_image', $banner_image );
 			update_option( 'wps_wgm_notify_new_banner_url', $banner_url );
-			if ( 'regular' == $banner_type ) {
+			if ( 'regular' === $banner_type ) {
 				update_option( 'wps_wgm_notify_hide_baneer_notification', 0 );
 			}
 		}
@@ -3222,16 +3222,16 @@ class Pdf_Generator_For_Wp_Admin {
 	 * @return void
 	 */
 	public function register_google_embed_blocks() {
-		$wps_wpg_is_pro_active = false;
+		$wps_wpg_is_pro_active  = false;
 		$wps_tofw_is_pro_active = false;
-		$wps_wpg_plugin_list = get_option( 'active_plugins' );
-		$wps_wpg_plugin = 'wordpress-pdf-generator/wordpress-pdf-generator.php';
-		if ( in_array( $wps_wpg_plugin, $wps_wpg_plugin_list ) ) {
+		$wps_wpg_plugin_list    = get_option( 'active_plugins' );
+		$wps_wpg_plugin         = 'wordpress-pdf-generator/wordpress-pdf-generator.php';
+		if ( in_array( $wps_wpg_plugin, $wps_wpg_plugin_list, true ) ) {
 			$wps_wpg_is_pro_active = true;
 		}
 
 		$wps_tofw_plugin = 'track-orders-for-woocommerce/track-orders-for-woocommerce.php';
-		if ( in_array( $wps_tofw_plugin, $wps_wpg_plugin_list ) ) {
+		if ( in_array( $wps_tofw_plugin, $wps_wpg_plugin_list, true ) ) {
 			$wps_tofw_is_pro_active = true;
 		}
 		$license_check = get_option( 'wps_wpg_license_check', 0 );
@@ -3253,11 +3253,11 @@ class Pdf_Generator_For_Wp_Admin {
 		register_block_type(
 			'custom/calendly-embed',
 			array(
-				'editor_script' => 'google-embed-block',
+				'editor_script'   => 'google-embed-block',
 				'render_callback' => 'wps_render_calendly_block',
-				'attributes' => array(
+				'attributes'      => array(
 					'url' => array(
-						'type' => 'string',
+						'type'    => 'string',
 						'default' => 'https://calendly.com/princekumaryadav-wpswings/new-meeting-2',
 					),
 				),
@@ -3268,23 +3268,23 @@ class Pdf_Generator_For_Wp_Admin {
 			'google-embed-block',
 			'embed_block_param',
 			array(
-				'ajaxurl'             => admin_url( 'admin-ajax.php' ),
-				'reloadurl'           => admin_url( 'admin.php?page=pdf_generator_for_wp_menu' ),
-				'is_pro_active' => $wps_wpg_is_pro_active,
-				'license_check' => $license_check,
-				'is_tofw_is_active' => $wps_tofw_is_pro_active,
-				'is_linkedln_active' => get_option( 'wps_embed_source_linkedln', '' ),
-				'is_loom_active' => get_option( 'wps_embed_source_loom', '' ),
-				'is_twitch_active' => get_option( 'wps_embed_source_twitch', '' ),
-				'is_ai_chatbot_active' => get_option( 'wps_embed_source_ai_chatbot', '' ),
-				'is_canva_active' => get_option( 'wps_embed_source_canva', '' ),
-				'is_reddit_active' => get_option( 'wps_embed_source_reddit', '' ),
-				'is_google_active' => get_option( 'wps_embed_source_google_elements', '' ),
-				'is_calendly_active' => get_option( 'wps_embed_source_calendly', '' ),
-				'is_strava_active' => get_option( 'wps_embed_source_strava', '' ),
-				'is_rss_feed_active' => get_option( 'wps_embed_source_rss_feed', '' ),
-				'is_x_active' => get_option( 'wps_embed_source_x', '' ),
-				'is_view_pdf_active' => get_option( 'wps_embed_source_pdf_embed', '' ),
+				'ajaxurl'                   => admin_url( 'admin-ajax.php' ),
+				'reloadurl'                 => admin_url( 'admin.php?page=pdf_generator_for_wp_menu' ),
+				'is_pro_active'             => $wps_wpg_is_pro_active,
+				'license_check'             => $license_check,
+				'is_tofw_is_active'         => $wps_tofw_is_pro_active,
+				'is_linkedln_active'        => get_option( 'wps_embed_source_linkedln', '' ),
+				'is_loom_active'            => get_option( 'wps_embed_source_loom', '' ),
+				'is_twitch_active'          => get_option( 'wps_embed_source_twitch', '' ),
+				'is_ai_chatbot_active'      => get_option( 'wps_embed_source_ai_chatbot', '' ),
+				'is_canva_active'           => get_option( 'wps_embed_source_canva', '' ),
+				'is_reddit_active'          => get_option( 'wps_embed_source_reddit', '' ),
+				'is_google_active'          => get_option( 'wps_embed_source_google_elements', '' ),
+				'is_calendly_active'        => get_option( 'wps_embed_source_calendly', '' ),
+				'is_strava_active'          => get_option( 'wps_embed_source_strava', '' ),
+				'is_rss_feed_active'        => get_option( 'wps_embed_source_rss_feed', '' ),
+				'is_x_active'               => get_option( 'wps_embed_source_x', '' ),
+				'is_view_pdf_active'        => get_option( 'wps_embed_source_pdf_embed', '' ),
 				'is_wps_track_order_active' => get_option( 'wps_embed_source_tracking_info', '' ),
 			)
 		);
@@ -3306,8 +3306,8 @@ class Pdf_Generator_For_Wp_Admin {
 	 */
 	public function wps_pgfw_save_embed_source_callback() {
 
-		$source = ! empty( $_POST['souce_name'] ) ? sanitize_text_field( wp_unslash( $_POST['souce_name'] ) ) : '';
-		$value = ! empty( $_POST['is_enable'] ) ? sanitize_text_field( wp_unslash( $_POST['is_enable'] ) ) : '';
+		$source    = ! empty( $_POST['souce_name'] ) ? sanitize_text_field( wp_unslash( $_POST['souce_name'] ) ) : '';
+		$value     = ! empty( $_POST['is_enable'] ) ? sanitize_text_field( wp_unslash( $_POST['is_enable'] ) ) : '';
 		$wps_nonce = ! empty( $_POST['nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['nonce'] ) ) : '';
 
 		if ( ! wp_verify_nonce( $wps_nonce, 'wps_wpg_embed_ajax_nonce' ) ) {
@@ -3351,13 +3351,13 @@ class Pdf_Generator_For_Wp_Admin {
 		register_post_type(
 			'flipbook',
 			array(
-				'label' => 'Flipbooks',
-				'public' => false,
-				'show_ui' => true,
+				'label'        => 'Flipbooks',
+				'public'       => false,
+				'show_ui'      => true,
 				'show_in_menu' => true, // Recommended for non-public, admin-only CPTs.
-				'menu_icon' => 'dashicons-book-alt',
-				'supports' => array( 'title' ),
-				'taxonomies' => array( 'flipbook_category' ),
+				'menu_icon'    => 'dashicons-book-alt',
+				'supports'     => array( 'title' ),
+				'taxonomies'   => array( 'flipbook_category' ),
 			)
 		);
 
@@ -3365,11 +3365,11 @@ class Pdf_Generator_For_Wp_Admin {
 			'flipbook_category',
 			'flipbook',
 			array(
-				'label' => 'Flipbook Categories',
-				'hierarchical' => true,
-				'show_ui' => true,
+				'label'             => 'Flipbook Categories',
+				'hierarchical'      => true,
+				'show_ui'           => true,
 				'show_admin_column' => true,
-				'rewrite' => array( 'slug' => 'flipbook-category' ),
+				'rewrite'           => array( 'slug' => 'flipbook-category' ),
 			)
 		);
 	}
@@ -3405,7 +3405,7 @@ class Pdf_Generator_For_Wp_Admin {
 	 * @param WP_Post $post Current post object.
 	 * @since 3.0.0
 	 */
-	public function wps_pgfw_useful_links_box( $post ) {
+	public function wps_pgfw_useful_links_box( $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- $post is required by the add_meta_box() callback signature.
 		// Fetch saved meta.
 		$demo_link   = 'https://demo.wpswings.com/pdf-generator-for-wp-pro/?utm_source=wpswings-pdf-demo&utm_medium=pdf-org-doc&utm_campaign=demo';
 		$video_link  = 'https://youtu.be/RljECeP3JJk';
@@ -3452,25 +3452,25 @@ class Pdf_Generator_For_Wp_Admin {
 		$width  = ! empty( get_post_meta( $post->ID, '_fb_width', true ) ) ? get_post_meta( $post->ID, '_fb_width', true ) : 1000;
 		$height = ! empty( get_post_meta( $post->ID, '_fb_height', true ) ) ? get_post_meta( $post->ID, '_fb_height', true ) : 1509;
 
-		$show_cover  = get_post_meta( $post->ID, '_fb_show_cover', true );
-		$cover_image = get_post_meta( $post->ID, '_fb_cover_image', true );
-		$back_image  = get_post_meta( $post->ID, '_fb_back_image', true );
-		$tool_btn    = get_post_meta( $post->ID, '_fb_tool_btn', true );
-		$pdf_url     = get_post_meta( $post->ID, '_fb_pdf_url', true );
-		$flip_sound_url = get_post_meta( $post->ID, '_fb_flip_sound_url', true );
+		$show_cover        = get_post_meta( $post->ID, '_fb_show_cover', true );
+		$cover_image       = get_post_meta( $post->ID, '_fb_cover_image', true );
+		$back_image        = get_post_meta( $post->ID, '_fb_back_image', true );
+		$tool_btn          = get_post_meta( $post->ID, '_fb_tool_btn', true );
+		$pdf_url           = get_post_meta( $post->ID, '_fb_pdf_url', true );
+		$flip_sound_url    = get_post_meta( $post->ID, '_fb_flip_sound_url', true );
 		$flip_sound_volume = get_post_meta( $post->ID, '_fb_flip_sound_volume', true );
-		$popup_enabled = get_post_meta( $post->ID, '_fb_popup_enabled', true );
-		$image_urls_json = get_post_meta( $post->ID, '_fb_image_urls', true );
-		$image_urls_json = is_string( $image_urls_json ) ? $image_urls_json : '';
+		$popup_enabled     = get_post_meta( $post->ID, '_fb_popup_enabled', true );
+		$image_urls_json   = get_post_meta( $post->ID, '_fb_image_urls', true );
+		$image_urls_json   = is_string( $image_urls_json ) ? $image_urls_json : '';
 
 		// ✅ Config values with defaults.
 		$mobile_scroll_support = get_post_meta( $post->ID, '_fb_mobileScrollSupport', true );
 		$max_shadow_opacity    = get_post_meta( $post->ID, '_fb_maxShadowOpacity', true );
-		$flipping_time        = get_post_meta( $post->ID, '_fb_flippingTime', true );
-		$start_page           = get_post_meta( $post->ID, '_fb_startPage', true );
-		$swipe_distance       = get_post_meta( $post->ID, '_fb_swipeDistance', true );
+		$flipping_time         = get_post_meta( $post->ID, '_fb_flippingTime', true );
+		$start_page            = get_post_meta( $post->ID, '_fb_startPage', true );
+		$swipe_distance        = get_post_meta( $post->ID, '_fb_swipeDistance', true );
 		$use_mouse_events      = get_post_meta( $post->ID, '_fb_useMouseEvents', true );
-		$size                = get_post_meta( $post->ID, '_fb_size', true );
+		$size                  = get_post_meta( $post->ID, '_fb_size', true );
 
 		$mobile_scroll_support = ( '' !== $mobile_scroll_support ) ? $mobile_scroll_support : '1';
 		$max_shadow_opacity    = ( '' !== $max_shadow_opacity ) ? $max_shadow_opacity : 0.5;
@@ -3557,7 +3557,7 @@ endif;
 					</tr>
 					<tr style="display:none;">
 
-						 <td><textarea name="fb_pdf_html" id="fb_pdf_html" rows="6" class="fb-wide"></textarea></td>
+						<td><textarea name="fb_pdf_html" id="fb_pdf_html" rows="6" class="fb-wide"></textarea></td>
 					</tr>
 					<tr>
 						<th><label for="fb_width"><?php esc_html_e( 'Width', 'pdf-generator-for-wp' ); ?></label>
@@ -3801,11 +3801,11 @@ endif;
 		}
 
 		// Validation: ensure at least one source (PDF or images) is provided.
-		$saved_pdf_url = get_post_meta( $post_id, '_fb_pdf_url', true );
+		$saved_pdf_url   = get_post_meta( $post_id, '_fb_pdf_url', true );
 		$saved_imgs_json = get_post_meta( $post_id, '_fb_image_urls', true );
-		$saved_imgs = $saved_imgs_json ? json_decode( $saved_imgs_json, true ) : array();
-		$has_images = is_array( $saved_imgs ) && count( $saved_imgs ) > 0;
-		$has_pdf = ! empty( $saved_pdf_url );
+		$saved_imgs      = $saved_imgs_json ? json_decode( $saved_imgs_json, true ) : array();
+		$has_images      = is_array( $saved_imgs ) && count( $saved_imgs ) > 0;
+		$has_pdf         = ! empty( $saved_pdf_url );
 		if ( ! $has_images && ! $has_pdf ) {
 			set_transient( 'wps_pgfw_notice_' . $post_id, 'Please set a Content Source: either select a PDF or choose images.', 60 );
 		} else {

--- a/admin/partials/pdf-generator-for-wp-admin-dashboard.php
+++ b/admin/partials/pdf-generator-for-wp-admin-dashboard.php
@@ -20,8 +20,8 @@ $pgfw_active_tab   = isset( $_GET['pgfw_tab'] ) ? sanitize_key( $_GET['pgfw_tab'
 do_action( 'pgfw_license_activation_notice_on_dashboard' );
 $pgfw_default_tabs = $pgfw_wps_pgfw_obj->wps_pgfw_plug_default_tabs();
 
-$wps_wpg_plugin_list = get_option( 'active_plugins' );
-$wps_wpg_plugin = 'wordpress-pdf-generator/wordpress-pdf-generator.php';
+$wps_wpg_plugin_list   = get_option( 'active_plugins' );
+$wps_wpg_plugin        = 'wordpress-pdf-generator/wordpress-pdf-generator.php';
 $wps_wpg_is_pro_active = false;
 if ( in_array( $wps_wpg_plugin, $wps_wpg_plugin_list ) ) {
 	$wps_wpg_is_pro_active = true;
@@ -95,7 +95,7 @@ if ( $pgfw_save_check_flag ) {
 	<?php
 		$plugin_admin = new Pdf_Generator_For_Wp_Admin( 'pdf-generator-for-wp', '1.0.7' );
 		$count        = $plugin_admin->wps_wpg_get_count( 'settings' );
-		$key3 = get_option( 'wps_wpg_activated_timestamp' );
+		$key3         = get_option( 'wps_wpg_activated_timestamp' );
 	if ( ! empty( $count ) && ( empty( $key3 ) ) ) {
 			$global_custom_css = 'const triggerError = () => {
 				swal({

--- a/admin/partials/pdf-generator-for-wp-cover-page-setting.php
+++ b/admin/partials/pdf-generator-for-wp-cover-page-setting.php
@@ -15,8 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 global $pgfw_wps_pgfw_obj, $pgfw_wps_wpg_obj;
-$pgfw_active_tab        = isset( $_GET['pgfw_tab'] ) ? sanitize_key( $_GET['pgfw_tab'] ) : 'pdf-generator-for-wp-layout-settings'; // phpcs:ignore WordPress.Security.NonceVerification
-$pgfw_default_tabs      = $pgfw_wps_pgfw_obj->wps_pgfw_plug_layout_setting_sub_tabs_dummy();
+$pgfw_active_tab         = isset( $_GET['pgfw_tab'] ) ? sanitize_key( $_GET['pgfw_tab'] ) : 'pdf-generator-for-wp-layout-settings'; // phpcs:ignore WordPress.Security.NonceVerification
+$pgfw_default_tabs       = $pgfw_wps_pgfw_obj->wps_pgfw_plug_layout_setting_sub_tabs_dummy();
 $pgfw_cover_setting_html = apply_filters( 'pgfw_layout_cover_page_setting_html_array_dummy', array() );
 ?>
 <main class="wps-main wps-bg-white wps-r-8 wps_pgfw_pro_tag">

--- a/admin/partials/pdf-generator-for-wp-embed-source.php
+++ b/admin/partials/pdf-generator-for-wp-embed-source.php
@@ -19,7 +19,7 @@ wps_embed_sources_page();
  * Description: Embeds a source Meeting.
  */
 function wps_embed_sources_page() {
-	 $sources = array( 'linkedln', 'loom', 'twitch', 'ai_chatbot', 'canva', 'reddit', 'google_elements', 'calendly', 'strava', 'rss_feed', 'x', 'pdf_embed', 'tracking_info' );
+	$sources = array( 'linkedln', 'loom', 'twitch', 'ai_chatbot', 'canva', 'reddit', 'google_elements', 'calendly', 'strava', 'rss_feed', 'x', 'pdf_embed', 'tracking_info' );
 
 	?>
 	<div class="wrap">
@@ -30,10 +30,10 @@ function wps_embed_sources_page() {
 		<div class="wps-embed-grid">
 			<?php
 			foreach ( $sources as $source ) :
-				$value = get_option( "wps_embed_source_{$source}", 'off' );
-				$label = ucfirst( str_replace( '_', ' ', $source ) );
+				$value       = get_option( "wps_embed_source_{$source}", 'off' );
+				$label       = ucfirst( str_replace( '_', ' ', $source ) );
 				$pro_sources = array( 'rss_feed', 'ai_chatbot', 'pdf_embed' );
-				$is_pro = in_array( $source, $pro_sources, true ); // you can customize this condition.
+				$is_pro      = in_array( $source, $pro_sources, true ); // you can customize this condition.
 				$is_disabled = $is_pro && ( ! is_plugin_active( 'wordpress-pdf-generator/wordpress-pdf-generator.php' ) );
 				?>
 				<div class="wps-embed-item <?php echo $is_disabled ? 'disabled-item' : ''; ?>">

--- a/admin/partials/pdf-generator-for-wp-internal-page-setting.php
+++ b/admin/partials/pdf-generator-for-wp-internal-page-setting.php
@@ -15,8 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 global $pgfw_wps_pgfw_obj, $pgfw_wps_wpg_obj;
-$pgfw_active_tab           = isset( $_GET['pgfw_tab'] ) ? sanitize_key( $_GET['pgfw_tab'] ) : 'pdf-generator-for-wp-layout-settings'; // phpcs:ignore WordPress.Security.NonceVerification
-$pgfw_default_tabs      = $pgfw_wps_pgfw_obj->wps_pgfw_plug_layout_setting_sub_tabs_dummy();
+$pgfw_active_tab   = isset( $_GET['pgfw_tab'] ) ? sanitize_key( $_GET['pgfw_tab'] ) : 'pdf-generator-for-wp-layout-settings'; // phpcs:ignore WordPress.Security.NonceVerification
+$pgfw_default_tabs = $pgfw_wps_pgfw_obj->wps_pgfw_plug_layout_setting_sub_tabs_dummy();
 
 $pgfw_template_settings_arr = apply_filters( 'wpg_tamplates_settings_array', array() );
 ?>
@@ -51,9 +51,9 @@ $pgfw_template_settings_arr = apply_filters( 'wpg_tamplates_settings_array', arr
 				<div class="wpg-admin-notice-custom"></div>
 				<div class="pgfw-secion-wrap">
 					<?php
-					$custom_template_data             = get_option( 'wpg_custom_templates_list', array() );
+					$custom_template_data              = get_option( 'wpg_custom_templates_list', array() );
 					$pgfw_use_template_to_generate_pdf = get_option( 'wpg_use_template_to_generate_pdf', array() );
-					$preview_output_href              = add_query_arg(
+					$preview_output_href               = add_query_arg(
 						array(
 							'action'   => 'previewpdf',
 							'template' => 'template1',
@@ -103,7 +103,7 @@ $pgfw_template_settings_arr = apply_filters( 'wpg_tamplates_settings_array', arr
 								<td><?php esc_html_e( 'Template 1', 'pdf-generator-for-wp' ); ?></td>
 								<td><?php esc_html_e( 'All Posts', 'pdf-generator-for-wp' ); ?></td>
 								<td>
-									<input type="checkbox" name="wpg_use_template_current_status[]" class="wpg_use_template_current_status" value="template1" <?php checked( in_array( 'template1', (array) $pgfw_use_template_to_generate_pdf ), true ); ?>>
+									<input type="checkbox" name="wpg_use_template_current_status[]" class="wpg_use_template_current_status" value="template1" <?php checked( in_array( 'template1', (array) $pgfw_use_template_to_generate_pdf, true ), true ); ?>>
 									<span><?php esc_html_e( 'Activate', 'pdf-generator-for-wp' ); ?></span>
 								</td>
 								<td>
@@ -145,7 +145,7 @@ $pgfw_template_settings_arr = apply_filters( 'wpg_tamplates_settings_array', arr
 												<span><select name="wpg_template_items[<?php echo esc_attr( $template ); ?>][]" class="wpg-select2" multiple style="width: 300px;">
 														<?php
 														$selected_items = get_option( 'wpg_template_items_' . $template, array() ); // need to get the selected items for this template.
-														$post_types = get_post_types( array( 'public' => true ), 'objects' );
+														$post_types     = get_post_types( array( 'public' => true ), 'objects' );
 
 														foreach ( $post_types as $wps_post_type ) {
 															$wps_single_posts = get_posts(
@@ -204,7 +204,7 @@ $pgfw_template_settings_arr = apply_filters( 'wpg_tamplates_settings_array', arr
 										<?php } ?>
 									</tr>
 									<?php
-									$i++;
+									++$i;
 								}
 							}
 							?>

--- a/admin/partials/pdf-generator-for-wp-layout-settings.php
+++ b/admin/partials/pdf-generator-for-wp-layout-settings.php
@@ -16,8 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit(); // Exit if accessed directly.
 }
 global $pgfw_wps_pgfw_obj, $pgfw_wps_wpg_obj;
-$pgfw_active_tab        = isset( $_GET['pgfw_tab'] ) ? sanitize_key( $_GET['pgfw_tab'] ) : 'pdf-generator-for-wp-layout-settings'; // phpcs:ignore WordPress.Security.NonceVerification
-$pgfw_default_tabs      = $pgfw_wps_pgfw_obj->wps_pgfw_plug_layout_setting_sub_tabs_dummy();
+$pgfw_active_tab         = isset( $_GET['pgfw_tab'] ) ? sanitize_key( $_GET['pgfw_tab'] ) : 'pdf-generator-for-wp-layout-settings'; // phpcs:ignore WordPress.Security.NonceVerification
+$pgfw_default_tabs       = $pgfw_wps_pgfw_obj->wps_pgfw_plug_layout_setting_sub_tabs_dummy();
 $pgfw_cover_setting_html = apply_filters( 'pgfw_plugin_standard_admin_settings_sub_tabs_dummy', array() );
 ?>
 <main class="wps-main wps-bg-white wps-r-8 wps_pgfw_pro_tag">

--- a/admin/partials/pdf-generator-for-wp-overview.php
+++ b/admin/partials/pdf-generator-for-wp-overview.php
@@ -15,14 +15,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 do_action( 'wps_pgfw_pro_overview_content' );
-$wps_wpg_plugin_list = get_option( 'active_plugins' );
-$wps_wpg_plugin = 'wordpress-pdf-generator/wordpress-pdf-generator.php';
+$wps_wpg_plugin_list   = get_option( 'active_plugins' );
+$wps_wpg_plugin        = 'wordpress-pdf-generator/wordpress-pdf-generator.php';
 $wps_wpg_is_pro_active = false;
-if ( in_array( $wps_wpg_plugin, $wps_wpg_plugin_list ) ) {
+if ( in_array( $wps_wpg_plugin, $wps_wpg_plugin_list, true ) ) {
 	$wps_wpg_is_pro_active = true;
 }
 
-if ( true != $wps_wpg_is_pro_active ) {
+if ( true !== $wps_wpg_is_pro_active ) {
 	?>
 <div class="wps-overview__wrapper">
 	<?php do_action( 'pgfw_overview_content_top' ); ?>

--- a/admin/partials/pdf-generator-for-wp-welcome.php
+++ b/admin/partials/pdf-generator-for-wp-welcome.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 global $pgfw_wps_pgfw_obj, $wps_pgfw_gen_flag, $pgfw_save_check_flag;
 $pgfw_default_tabs = $pgfw_wps_pgfw_obj->wps_pgfw_plug_default_tabs();
-$pgfw_tab_key = '';
+$pgfw_tab_key      = '';
 ?>
 <header>
 	<?php
@@ -39,22 +39,22 @@ $pgfw_tab_key = '';
 				array(
 
 					array(
-						'title'       => __( 'Enable Tracking', 'pdf-generator-for-wp' ),
-						'type'        => 'radio-switch',
-						'name'        => 'pgfw_enable_tracking',
-						'id'          => 'pgfw_enable_tracking',
-						'value'       => get_option( 'pgfw_enable_tracking' ),
-						'class'       => 'pgfw-radio-switch-class',
-						'options'     => array(
+						'title'   => __( 'Enable Tracking', 'pdf-generator-for-wp' ),
+						'type'    => 'radio-switch',
+						'name'    => 'pgfw_enable_tracking',
+						'id'      => 'pgfw_enable_tracking',
+						'value'   => get_option( 'pgfw_enable_tracking' ),
+						'class'   => 'pgfw-radio-switch-class',
+						'options' => array(
 							'yes' => __( 'YES', 'pdf-generator-for-wp' ),
 							'no'  => __( 'NO', 'pdf-generator-for-wp' ),
 						),
 					),
 					array(
-						'type'  => 'button',
-						'id'    => 'pgfw_tracking_save_button',
+						'type'        => 'button',
+						'id'          => 'pgfw_tracking_save_button',
 						'button_text' => __( 'Save', 'pdf-generator-for-wp' ),
-						'class' => 'pgfw-button-class',
+						'class'       => 'pgfw-button-class',
 					),
 				)
 			);
@@ -78,9 +78,9 @@ $pgfw_tab_key = '';
 	</section>
 	<style type="text/css">
 		.cards {
-			   display: flex;
-			   flex-wrap: wrap;
-			   padding: 20px 40px;
+				display: flex;
+				flex-wrap: wrap;
+				padding: 20px 40px;
 		}
 		.card {
 			flex: 1 0 518px;

--- a/admin/partials/pdf_templates/pdf-generator-for-wp-admin-template1.php
+++ b/admin/partials/pdf_templates/pdf-generator-for-wp-admin-template1.php
@@ -24,14 +24,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @return string
  */
-function return_ob_html( $post_id, $template_name = '' ) {
+function return_ob_html( $post_id, $template_name = '' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- $template_name is kept for template-selection API compatibility.
 	do_action( 'wps_pgfw_load_all_compatible_shortcode_converter' );
 
-	$pgfw_display_settings                   = get_option( 'pgfw_save_admin_display_settings', array() );
+	$pgfw_display_settings = get_option( 'pgfw_save_admin_display_settings', array() );
 	// advanced settings.
-	$pgfw_advanced_settings = get_option( 'pgfw_advanced_save_settings', array() );
-	$pgfw_ttf_font_upload   = array_key_exists( 'pgfw_ttf_font_upload', $pgfw_advanced_settings ) ? $pgfw_advanced_settings['pgfw_ttf_font_upload'] : '';
-	$pgfw_template_color_option                 = array_key_exists( 'pgfw_template_color_option', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_color_option'] : '';
+	$pgfw_advanced_settings     = get_option( 'pgfw_advanced_save_settings', array() );
+	$pgfw_ttf_font_upload       = array_key_exists( 'pgfw_ttf_font_upload', $pgfw_advanced_settings ) ? $pgfw_advanced_settings['pgfw_ttf_font_upload'] : '';
+	$pgfw_template_color_option = array_key_exists( 'pgfw_template_color_option', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_color_option'] : '';
 	// header customisation settings.
 	$pgfw_header_settings   = get_option( 'pgfw_header_setting_submit', array() );
 	$pgfw_header_use_in_pdf = array_key_exists( 'pgfw_header_use_in_pdf', $pgfw_header_settings ) ? $pgfw_header_settings['pgfw_header_use_in_pdf'] : '';
@@ -46,7 +46,7 @@ function return_ob_html( $post_id, $template_name = '' ) {
 	$pgfw_header_top        = array_key_exists( 'pgfw_header_top', $pgfw_header_settings ) ? $pgfw_header_settings['pgfw_header_top'] : '';
 	// body customisation settings.
 	$pgfw_body_settings              = get_option( 'pgfw_body_save_settings', array() );
-	$pgfw_body_spcl_char_support      = array_key_exists( 'pgfw_body_spcl_char_support', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_spcl_char_support'] : '';
+	$pgfw_body_spcl_char_support     = array_key_exists( 'pgfw_body_spcl_char_support', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_spcl_char_support'] : '';
 	$pgfw_body_title_font_style      = array_key_exists( 'pgfw_body_title_font_style', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_title_font_style'] : '';
 	$pgfw_body_title_font_style      = ( 'custom' === $pgfw_body_title_font_style ) ? 'My_font' : $pgfw_body_title_font_style;
 	$pgfw_body_title_font_size       = array_key_exists( 'pgfw_body_title_font_size', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_title_font_size'] : '';
@@ -69,54 +69,54 @@ function return_ob_html( $post_id, $template_name = '' ) {
 	$pgfw_border_position_right      = array_key_exists( 'pgfw_border_position_right', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_border_position_right'] : '';
 	$pgfw_body_custom_css            = array_key_exists( 'pgfw_body_custom_css', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_custom_css'] : '';
 	$pgfw_body_watermark_text        = array_key_exists( 'pgfw_body_watermark_text', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_watermark_text'] : '';
-	$pgfw_body_add_watermark        = array_key_exists( 'pgfw_body_add_watermark', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_add_watermark'] : '';
-	$pgfw_body_watermark_color        = array_key_exists( 'pgfw_body_watermark_color', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_watermark_color'] : '';
-	$pgfw_body_customization     = array_key_exists( 'pgfw_body_customization_for_post_detail', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_customization_for_post_detail'] : '';
+	$pgfw_body_add_watermark         = array_key_exists( 'pgfw_body_add_watermark', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_add_watermark'] : '';
+	$pgfw_body_watermark_color       = array_key_exists( 'pgfw_body_watermark_color', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_watermark_color'] : '';
+	$pgfw_body_customization         = array_key_exists( 'pgfw_body_customization_for_post_detail', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_customization_for_post_detail'] : '';
 	// general settings.
-	$general_settings_data     = get_option( 'pgfw_general_settings_save', array() );
-	$pgfw_show_post_categories = array_key_exists( 'pgfw_general_pdf_show_categories', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_categories'] : '';
-	$pgfw_show_post_tags       = array_key_exists( 'pgfw_general_pdf_show_tags', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_tags'] : '';
-	$pgfw_show_post_taxonomy   = array_key_exists( 'pgfw_general_pdf_show_taxonomy', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_taxonomy'] : '';
-	$pgfw_show_post_date       = array_key_exists( 'pgfw_general_pdf_show_post_date', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_post_date'] : '';
+	$general_settings_data        = get_option( 'pgfw_general_settings_save', array() );
+	$pgfw_show_post_categories    = array_key_exists( 'pgfw_general_pdf_show_categories', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_categories'] : '';
+	$pgfw_show_post_tags          = array_key_exists( 'pgfw_general_pdf_show_tags', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_tags'] : '';
+	$pgfw_show_post_taxonomy      = array_key_exists( 'pgfw_general_pdf_show_taxonomy', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_taxonomy'] : '';
+	$pgfw_show_post_date          = array_key_exists( 'pgfw_general_pdf_show_post_date', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_post_date'] : '';
 	$pgfw_show_current_date       = array_key_exists( 'pgfw_general_pdf_show_current_date', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_current_date'] : '';
-	$pgfw_show_post_author     = array_key_exists( 'pgfw_general_pdf_show_author_name', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_author_name'] : '';
-	$pgfw_general_pdf_date_format    = array_key_exists( 'pgfw_general_pdf_date_format', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_date_format'] : '';
+	$pgfw_show_post_author        = array_key_exists( 'pgfw_general_pdf_show_author_name', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_author_name'] : '';
+	$pgfw_general_pdf_date_format = array_key_exists( 'pgfw_general_pdf_date_format', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_date_format'] : '';
 
-	$pgfw_template_color               = array_key_exists( 'pgfw_template_color', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_color'] : '#FFFFFF';
-	$pgfw_template_text_color       = array_key_exists( 'pgfw_template_text_color', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_text_color'] : '#000000';
+	$pgfw_template_color      = array_key_exists( 'pgfw_template_color', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_color'] : '#FFFFFF';
+	$pgfw_template_text_color = array_key_exists( 'pgfw_template_text_color', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_text_color'] : '#000000';
 	// meta fields settings.
-	$pgfw_meta_settings = get_option( 'pgfw_meta_fields_save_settings', array() );
+	$pgfw_meta_settings                  = get_option( 'pgfw_meta_fields_save_settings', array() );
 	$pgfw_meta_fields_show_image_gallery = array_key_exists( 'pgfw_meta_fields_show_image_gallery', $pgfw_meta_settings ) ? $pgfw_meta_settings['pgfw_meta_fields_show_image_gallery'] : '';
-	$pgfw_gallery_metafield_key = array_key_exists( 'pgfw_gallery_metafield_key', $pgfw_meta_settings ) ? $pgfw_meta_settings['pgfw_gallery_metafield_key'] : '';
+	$pgfw_gallery_metafield_key          = array_key_exists( 'pgfw_gallery_metafield_key', $pgfw_meta_settings ) ? $pgfw_meta_settings['pgfw_gallery_metafield_key'] : '';
 	// footer settings.
-	$pgfw_footer_settings   = get_option( 'pgfw_footer_setting_submit', array() );
-	$pgfw_footer_use_in_pdf = array_key_exists( 'pgfw_footer_use_in_pdf', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_use_in_pdf'] : '';
-	$pgfw_footer_tagline    = array_key_exists( 'pgfw_footer_tagline', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_tagline'] : '';
-	$pgfw_footer_color      = array_key_exists( 'pgfw_footer_color', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_color'] : '';
-	$pgfw_footer_width      = array_key_exists( 'pgfw_footer_width', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_width'] : '';
-	$pgfw_footer_font_style = array_key_exists( 'pgfw_footer_font_style', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_font_style'] : '';
-	$pgfw_footer_font_style = ( 'custom' === $pgfw_footer_font_style ) ? 'My_font' : $pgfw_footer_font_style;
-	$pgfw_footer_font_size  = array_key_exists( 'pgfw_footer_font_size', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_font_size'] : '';
-	$pgfw_footer_bottom     = array_key_exists( 'pgfw_footer_bottom', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_bottom'] : '';
-	$pgfw_footer_customization     = array_key_exists( 'pgfw_footer_customization_for_post_detail', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_customization_for_post_detail'] : '';
-	$pgfw_body_meta_field_column     = array_key_exists( 'pgfw_body_meta_field_column', $pgfw_body_settings ) ? intval( $pgfw_body_settings['pgfw_body_meta_field_column'] ) : '';
-	$pgfw_body_images_row_wise     = array_key_exists( 'pgfw_body_images_row_wise', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_images_row_wise'] : '';
+	$pgfw_footer_settings        = get_option( 'pgfw_footer_setting_submit', array() );
+	$pgfw_footer_use_in_pdf      = array_key_exists( 'pgfw_footer_use_in_pdf', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_use_in_pdf'] : '';
+	$pgfw_footer_tagline         = array_key_exists( 'pgfw_footer_tagline', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_tagline'] : '';
+	$pgfw_footer_color           = array_key_exists( 'pgfw_footer_color', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_color'] : '';
+	$pgfw_footer_width           = array_key_exists( 'pgfw_footer_width', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_width'] : '';
+	$pgfw_footer_font_style      = array_key_exists( 'pgfw_footer_font_style', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_font_style'] : '';
+	$pgfw_footer_font_style      = ( 'custom' === $pgfw_footer_font_style ) ? 'My_font' : $pgfw_footer_font_style;
+	$pgfw_footer_font_size       = array_key_exists( 'pgfw_footer_font_size', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_font_size'] : '';
+	$pgfw_footer_bottom          = array_key_exists( 'pgfw_footer_bottom', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_bottom'] : '';
+	$pgfw_footer_customization   = array_key_exists( 'pgfw_footer_customization_for_post_detail', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_customization_for_post_detail'] : '';
+	$pgfw_body_meta_field_column = array_key_exists( 'pgfw_body_meta_field_column', $pgfw_body_settings ) ? intval( $pgfw_body_settings['pgfw_body_meta_field_column'] ) : '';
+	$pgfw_body_images_row_wise   = array_key_exists( 'pgfw_body_images_row_wise', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_images_row_wise'] : '';
 
-	$status  = get_option( 'status' );
+	$status = get_option( 'status' );
 
-	if ( '' == $pgfw_footer_customization ) {
+	if ( '' === $pgfw_footer_customization ) {
 		$pgfw_footer_customization = array();
 	}
-	if ( '' == $status ) {
-		$post = get_post( $post_id );
-		$author_id = get_post_field( 'post_author', $post_id );
+	if ( empty( $status ) ) {
+		$post         = get_post( $post_id );
+		$author_id    = get_post_field( 'post_author', $post_id );
 		$display_name = get_the_author_meta( 'display_name', $author_id );
-		$post_date = get_the_date( $pgfw_general_pdf_date_format, $post_id );
-		$post_title = get_the_title( $post );
+		$post_date    = get_the_date( $pgfw_general_pdf_date_format, $post_id );
+		$post_title   = get_the_title( $post );
 	}
-		$display_author_name = in_array( 'author', $pgfw_footer_customization ) ? $display_name : '';
-		$display_post_date = in_array( 'post_date', $pgfw_footer_customization ) ? $post_date : '';
-		$display_post_title = in_array( 'post_title', $pgfw_footer_customization ) ? $post_title : '';
+		$display_author_name = in_array( 'author', $pgfw_footer_customization, true ) ? $display_name : '';
+		$display_post_date   = in_array( 'post_date', $pgfw_footer_customization, true ) ? $post_date : '';
+		$display_post_title  = in_array( 'post_title', $pgfw_footer_customization, true ) ? $post_title : '';
 	if ( 'yes' === $pgfw_body_rtl_support ) {
 		$pgfw_header_font_style     = 'DejaVu Sans, sans-serif';
 		$pgfw_body_page_font_style  = 'DejaVu Sans, sans-serif';
@@ -148,7 +148,7 @@ function return_ob_html( $post_id, $template_name = '' ) {
 				</style>';
 		}
 	}
-	if ( 'yes' != $pgfw_body_spcl_char_support ) {
+	if ( 'yes' !== $pgfw_body_spcl_char_support ) {
 		$html .= '<style>
 		<meta charset="UTF-8">
 		<style>
@@ -178,15 +178,15 @@ function return_ob_html( $post_id, $template_name = '' ) {
 		</style>
 		<div class="pgfw-border-page" >';
 	}
-	if ( 'yes' == $pgfw_body_add_watermark ) {
+	if ( 'yes' === $pgfw_body_add_watermark ) {
 		$watermark = $pgfw_body_watermark_text;
 	} else {
 		$watermark = '';
 	}
 	// Header for pdf.
 	if ( 'yes' === $pgfw_header_use_in_pdf ) {
-		$pgfw_header_logo_size  = array_key_exists( 'pgfw_header_logo_size', $pgfw_header_settings ) ? $pgfw_header_settings['pgfw_header_logo_size'] : '30';
-		$html .= '<style>
+		$pgfw_header_logo_size = array_key_exists( 'pgfw_header_logo_size', $pgfw_header_settings ) ? $pgfw_header_settings['pgfw_header_logo_size'] : '30';
+		$html                 .= '<style>
 					.pgfw-pdf-header-each-page{
 						position : fixed;
 						left     : 0px;
@@ -312,7 +312,7 @@ function return_ob_html( $post_id, $template_name = '' ) {
 					
 					';
 
-		if ( 'yes' == $pgfw_template_color_option ) {
+		if ( 'yes' === $pgfw_template_color_option ) {
 			$html .= '
 			.pgfw-pdf-body {
 			  position: fixed;
@@ -328,7 +328,7 @@ function return_ob_html( $post_id, $template_name = '' ) {
 			';
 		}
 
-		if ( 'yes' == $pgfw_body_images_row_wise ) {
+		if ( 'yes' === $pgfw_body_images_row_wise ) {
 
 			$html .= '	.pgfw-pdf-body-content .wp-block-columns:after {
 						content: "";
@@ -372,16 +372,16 @@ function return_ob_html( $post_id, $template_name = '' ) {
 								}';
 		}
 
-		$html   .= '</style>
+		$html .= '</style>
 		<div class="pgfw-pdf-body" >';
-		if ( ! empty( $pgfw_body_customization ) && in_array( 'post_thumb', $pgfw_body_customization ) ) {
+		if ( ! empty( $pgfw_body_customization ) && in_array( 'post_thumb', $pgfw_body_customization, true ) ) {
 			$html .= '';
 		} else {
 			$html .= '<div class="pgfw-pdf-body-title-image">
 					<img src="' . get_the_post_thumbnail_url( $post ) . '">
 				</div>';
 		}
-		if ( ! empty( $pgfw_body_customization ) && in_array( 'title', $pgfw_body_customization ) ) {
+		if ( ! empty( $pgfw_body_customization ) && in_array( 'title', $pgfw_body_customization, true ) ) {
 			$html .= '';
 		} else {
 			$html .= '<div class="pgfw-pdf-body-title">
@@ -390,7 +390,7 @@ function return_ob_html( $post_id, $template_name = '' ) {
 		}
 
 		$html .= '	<div class="pgfw-pdf-body-content">';
-		if ( ! empty( $pgfw_body_customization ) && in_array( 'description', $pgfw_body_customization ) ) {
+		if ( ! empty( $pgfw_body_customization ) && in_array( 'description', $pgfw_body_customization, true ) ) {
 			$html .= '';
 		} else {
 			$html .= '	<h3>' . esc_html__( 'Description', 'pdf-generator-for-wp' ) . '</h3>';
@@ -463,35 +463,35 @@ function return_ob_html( $post_id, $template_name = '' ) {
 			$html       .= '<div>' . $author_name . '</div>';
 		}
 		// meta fields.
-		$post_type               = $post->post_type;
-		$pgfw_show_type_meta_val = array_key_exists( 'pgfw_meta_fields_' . $post_type . '_show', $pgfw_meta_settings ) ? $pgfw_meta_settings[ 'pgfw_meta_fields_' . $post_type . '_show' ] : '';
-		$pgfw_show_type_meta_arr = array_key_exists( 'pgfw_meta_fields_' . $post_type . '_list', $pgfw_meta_settings ) ? $pgfw_meta_settings[ 'pgfw_meta_fields_' . $post_type . '_list' ] : array();
-		$pgfw_body_metafields_row_wise     = array_key_exists( 'pgfw_body_metafields_row_wise', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_metafields_row_wise'] : '';
-		$html2                   = '';
+		$post_type                     = $post->post_type;
+		$pgfw_show_type_meta_val       = array_key_exists( 'pgfw_meta_fields_' . $post_type . '_show', $pgfw_meta_settings ) ? $pgfw_meta_settings[ 'pgfw_meta_fields_' . $post_type . '_show' ] : '';
+		$pgfw_show_type_meta_arr       = array_key_exists( 'pgfw_meta_fields_' . $post_type . '_list', $pgfw_meta_settings ) ? $pgfw_meta_settings[ 'pgfw_meta_fields_' . $post_type . '_list' ] : array();
+		$pgfw_body_metafields_row_wise = array_key_exists( 'pgfw_body_metafields_row_wise', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_metafields_row_wise'] : '';
+		$html2                         = '';
 		if ( 'yes' === $pgfw_show_type_meta_val ) {
 			if ( is_array( $pgfw_show_type_meta_arr ) ) {
 				$html2 .= '<div><b>' . __( 'Meta Fields', 'pdf-generator-for-wp' ) . '</b></div>';
 				$html2 .= '<table><tr>';
 				foreach ( $pgfw_show_type_meta_arr as $meta_key ) {
-					$meta_val          = get_post_meta( $post->ID, $meta_key, true );
+					$meta_val           = get_post_meta( $post->ID, $meta_key, true );
 					$pgfw_meta_key_name = ucwords( str_replace( '_', ' ', $meta_key ) );
 
 					if ( $meta_val ) {
-						if ( ( '_product_image_gallery' == $meta_key ) || ( 'yes' == ( $pgfw_meta_fields_show_image_gallery ) && ! empty( $pgfw_gallery_metafield_key ) && ( $pgfw_gallery_metafield_key == $meta_key ) ) ) {
+						if ( ( '_product_image_gallery' === $meta_key ) || ( 'yes' === ( $pgfw_meta_fields_show_image_gallery ) && ! empty( $pgfw_gallery_metafield_key ) && ( $pgfw_gallery_metafield_key === $meta_key ) ) ) {
 							$meta_val1 = explode( ',', $meta_val );
 							foreach ( $meta_val1 as $key => $val ) {
 
 								$thumbnail_url = get_the_guid( $val );
-								$thumbnail = '<img  src=' . $thumbnail_url . ' alt="post thumbnail" style="height:100px; width: 100px; margin:17px;" height=50 weight=50/>';
-								$html2 .= $thumbnail;
+								$thumbnail     = '<img  src=' . $thumbnail_url . ' alt="post thumbnail" style="height:100px; width: 100px; margin:17px;" height=50 weight=50/>';
+								$html2        .= $thumbnail;
 							}
 							$html2 .= '<div><b> ' . $pgfw_meta_key_name . '</b> </div>';
 
-						} elseif ( 'yes' == $pgfw_body_metafields_row_wise ) {
-								$i++;
+						} elseif ( 'yes' === $pgfw_body_metafields_row_wise ) {
+								++$i;
 								$html2 .= '<td><b>' . $pgfw_meta_key_name . ' :</b></td>';
 								$html2 .= '<td> ' . $meta_val . ' </td>';
-							if ( 0 == $i % $pgfw_body_meta_field_column ) {
+							if ( 0 === $i % $pgfw_body_meta_field_column ) {
 								$html2 .= '</tr><tr>';
 							}
 						} else {

--- a/admin/partials/pdf_templates/pdf-generator-for-wp-invoice-pdflayout1.php
+++ b/admin/partials/pdf_templates/pdf-generator-for-wp-invoice-pdflayout1.php
@@ -266,7 +266,7 @@ function return_ob_value( $order_id, $type, $invoice_id ) {
 						</tr>
 					</thead>
 					<tbody>';
-			$meta_data = '';
+			$meta_data             = '';
 			foreach ( $order_product_details as $key => $product ) {
 				$item_data = ! empty( $product['item_meta'] ) ? $product['item_meta'] : array();
 				if ( ! empty( $item_data ) && is_array( $item_data ) ) {
@@ -279,7 +279,7 @@ function return_ob_value( $order_id, $type, $invoice_id ) {
 						$meta_data .= '<br>' . $item['display_key'] . ':' . $item['display_value'];
 					}
 				}
-				$html .= '<tr>
+				$html                 .= '<tr>
 								<td style="text-align: left;padding: 10px;">' . $product['product_name'] . $meta_data . '</td>
 								<td style="text-align: left;padding: 10px;">' . $product['product_quantity'] . '</td>';
 								$html .= '<td style="text-align: left;padding: 10px;">' . apply_filters( 'wps_custom_column_html_column_data', '', $order_id, $type, $invoice_id ) . '</td>';

--- a/admin/partials/pdf_templates/pdf-generator-for-wp-invoice-pdflayout2.php
+++ b/admin/partials/pdf_templates/pdf-generator-for-wp-invoice-pdflayout2.php
@@ -20,9 +20,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function return_ob_value( $order_id, $type, $invoice_id ) {
 
-	$order_details         = do_shortcode( '[WPG_FETCH_ORDER order_id ="' . $order_id . '"]' );
+	$order_details = do_shortcode( '[WPG_FETCH_ORDER order_id ="' . $order_id . '"]' );
 
-	$order_details         = json_decode( $order_details, true );
+	$order_details = json_decode( $order_details, true );
 
 	$shipping_details      = $order_details['shipping_details'];
 	$billing_details       = $order_details['billing_details'];
@@ -230,7 +230,7 @@ function return_ob_value( $order_id, $type, $invoice_id ) {
 					</table>';
 
 		if ( 'invoice' === $type ) {
-			$html .= '<div>
+			$html                         .= '<div>
 						<table border = "0" cellpadding = "0" cellspacing = "0" id="wpg-prod-listing-table">
 							<thead>
 								<tr id="wpg-prod-listing-table-title">
@@ -243,7 +243,7 @@ function return_ob_value( $order_id, $type, $invoice_id ) {
 								</tr>
 							</thead>
 							<tbody id="wpg-pdf-prod-body">';
-			$meta_data = '';
+			$meta_data                     = '';
 			foreach ( $order_product_details as $product ) {
 				$item_data = ! empty( $product['item_meta'] ) ? $product['item_meta'] : array();
 				if ( ! empty( $item_data ) && is_array( $item_data ) ) {
@@ -256,7 +256,7 @@ function return_ob_value( $order_id, $type, $invoice_id ) {
 						$meta_data .= '<br/>' . $item['display_key'] . ':' . $item['display_value'];
 					}
 				}
-				$html .= '<tr>
+				$html         .= '<tr>
 						<td class="wpg-product-name">' . $product['product_name'] . $meta_data . '</td>
 						<td>' . $product['product_quantity'] . '</td>';
 						$html .= '<td>' . apply_filters( 'wps_custom_column_html_column_data', '', $order_id, $type, $invoice_id ) . '</td>';

--- a/admin/partials/pdf_templates/pdf-generator-for-wp-invoice-pdflayout3.php
+++ b/admin/partials/pdf_templates/pdf-generator-for-wp-invoice-pdflayout3.php
@@ -20,9 +20,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function return_ob_value( $order_id, $type, $invoice_id ) {
 
-	$order_details         = do_shortcode( '[WPG_FETCH_ORDER order_id ="' . $order_id . '"]' );
+	$order_details = do_shortcode( '[WPG_FETCH_ORDER order_id ="' . $order_id . '"]' );
 
-	$order_details         = json_decode( $order_details, true );
+	$order_details = json_decode( $order_details, true );
 
 	$shipping_details      = $order_details['shipping_details'];
 	$billing_details       = $order_details['billing_details'];
@@ -256,7 +256,7 @@ function return_ob_value( $order_id, $type, $invoice_id ) {
 		if ( 'yes' === $is_add_logo && '' !== $logo ) {
 			$html .= ' <img src="' . $logo . '" >';
 		}
-		 $html .= ' </div>
+		$html .= ' </div>
       <div id="company">
         <h2 class="name"><b>' . ucfirst( $company_name ) . '</b></h2>
         <div>' . ucfirst( $company_address ) . '</div>
@@ -289,7 +289,7 @@ function return_ob_value( $order_id, $type, $invoice_id ) {
 
 			$html .= '<th>' . apply_filters( 'wps_custom_column_html_column_head', '', $order_id, $type, $invoice_id ) . '</th>';
 
-			$html .= '<th>' . __( 'Price', 'pdf-generator-for-wp' ) . '(' . $billing_details['order_currency'] . ')</th>
+			$html     .= '<th>' . __( 'Price', 'pdf-generator-for-wp' ) . '(' . $billing_details['order_currency'] . ')</th>
         <th>' . __( 'Tax', 'pdf-generator-for-wp' ) . ' (%)</th>
         <th>' . __( 'Amount', 'pdf-generator-for-wp' ) . '(' . $billing_details['order_currency'] . ')</th>
       </tr>
@@ -297,8 +297,8 @@ function return_ob_value( $order_id, $type, $invoice_id ) {
         <tbody>
         ';
 			$meta_data = '';
-			$i = 1;
-			$total = 0;
+			$i         = 1;
+			$total     = 0;
 
 			foreach ( $order_product_details as $product ) {
 
@@ -313,22 +313,22 @@ function return_ob_value( $order_id, $type, $invoice_id ) {
 						$meta_data .= '<br/>' . $item['display_key'] . ':' . $item['display_value'];
 					}
 				}
-				$html .= '
+				$html         .= '
             <tr>
 						<td class="wpg-product-name no">' . $product['product_name'] . $meta_data . '</td>
 						<td class="desc"> ' . $product['product_quantity'] . '</td>';
-				$html .= '<td class="desc">' . apply_filters( 'wps_custom_column_html_column_data', '', $order_id, $type, $invoice_id ) . '</td>';
+				$html         .= '<td class="desc">' . apply_filters( 'wps_custom_column_html_column_data', '', $order_id, $type, $invoice_id ) . '</td>';
 						$html .= '<td class="unit">' . $product['product_price'] . '</td>
 						<td class="qty" >' . $product['tax_percent'] . '</td>
 						<td class="total">' . $product['product_total'] . '</td>
 					</tr>
             
          ';
-				$i++;
+				++$i;
 				$total += $product['product_price'] * $product['product_quantity'];
 			}
 
-			$html .= ' </tbody>
+			$html               .= ' </tbody>
         <tfoot>
           <tr>
           <td ></td>
@@ -401,7 +401,7 @@ function return_ob_value( $order_id, $type, $invoice_id ) {
 
 			$html .= '</main>';
 		}
-		$html .= '<footer>
+		$html         .= '<footer>
       Invoice was created on a computer and is valid without the signature and seal.
     </footer>';
 				$html .= '</body>

--- a/admin/partials/pdf_templates/pdf-generator-for-wp-invoice-share-helper.php
+++ b/admin/partials/pdf_templates/pdf-generator-for-wp-invoice-share-helper.php
@@ -63,11 +63,11 @@ if ( ! function_exists( 'wpg_invoice_share_section' ) ) {
 	 * @return string
 	 */
 	function wpg_invoice_share_section( $share_link, $color, $whatsapp_share, $email_share ) {
-		$share_link            = esc_url( $share_link );
-		$whatsapp_share        = esc_url( $whatsapp_share );
-		$email_share           = esc_url( $email_share );
-		$color_style           = $color ? $color : '#000000';
-		$open_link_text        = esc_attr__( 'Open invoice link', 'pdf-generator-for-wp' );
+		$share_link     = esc_url( $share_link );
+		$whatsapp_share = esc_url( $whatsapp_share );
+		$email_share    = esc_url( $email_share );
+		$color_style    = $color ? $color : '#000000';
+		$open_link_text = esc_attr__( 'Open invoice link', 'pdf-generator-for-wp' );
 
 		$html  = '<div style="text-align:center; padding:14px; border:1px solid #e6e6e6; border-radius:8px; background:#fafafa;">';
 		$html .= '<div style="font-weight:700; letter-spacing:0.3px; margin-bottom:15px; color:' . esc_attr( $color_style ) . '; text-transform:uppercase; font-size:13px;">' . __( 'Share this invoice', 'pdf-generator-for-wp' ) . '</div>';

--- a/common/class-pdf-generator-for-wp-common.php
+++ b/common/class-pdf-generator-for-wp-common.php
@@ -164,22 +164,22 @@ class Pdf_Generator_For_Wp_Common {
 		require_once PDF_GENERATOR_FOR_WP_DIR_PATH . 'package/lib/dompdf/vendor/autoload.php';
 
 		$pgfw_meta_settings = get_option( 'pgfw_meta_fields_save_settings', array() );
-		 // unknow image file handler.
+		// unknow image file handler.
 		$pgfw_meta_fields_show_unknown_image_format = array_key_exists( 'pgfw_meta_fields_show_unknown_image_format', $pgfw_meta_settings ) ? $pgfw_meta_settings['pgfw_meta_fields_show_unknown_image_format'] : '';
 		// footer .
-		$pgfw_footer_settings   = get_option( 'pgfw_footer_setting_submit', array() );
+		$pgfw_footer_settings         = get_option( 'pgfw_footer_setting_submit', array() );
 		$pgfw_general_pdf_show_pageno = array_key_exists( 'pgfw_general_pdf_show_pageno', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_general_pdf_show_pageno'] : '';
 		$pgfw_pageno_position_left    = array_key_exists( 'pgfw_pageno_position_left', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_pageno_position_left'] : '';
-		$pgfw_pageno_position_top    = array_key_exists( 'pgfw_pageno_position_top', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_pageno_position_top'] : '';
+		$pgfw_pageno_position_top     = array_key_exists( 'pgfw_pageno_position_top', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_pageno_position_top'] : '';
 
 		// end footer .
-		$body_settings_arr       = get_option( 'pgfw_body_save_settings', array() );
-		$pgfw_body_custom_page_size_height        = array_key_exists( 'pgfw_body_custom_page_size_height', $body_settings_arr ) ? $body_settings_arr['pgfw_body_custom_page_size_height'] : '';
-		$pgfw_body_custom_page_size_width        = array_key_exists( 'pgfw_body_custom_page_size_width', $body_settings_arr ) ? $body_settings_arr['pgfw_body_custom_page_size_width'] : '';
-		$pgfw_body_page_template = array_key_exists( 'pgfw_body_page_template', $body_settings_arr ) ? $body_settings_arr['pgfw_body_page_template'] : 'template1';
-		$pgfw_body_post_template = array_key_exists( 'pgfw_body_post_template', $body_settings_arr ) ? $body_settings_arr['pgfw_body_post_template'] : 'template1';
-		$pgfw_body_spcl_char_support = array_key_exists( 'pgfw_body_spcl_char_support', $body_settings_arr ) ? $body_settings_arr['pgfw_body_spcl_char_support'] : '';
-		$post_id                 = is_array( $prod_id ) ? $prod_id[0] : $prod_id;
+		$body_settings_arr                 = get_option( 'pgfw_body_save_settings', array() );
+		$pgfw_body_custom_page_size_height = array_key_exists( 'pgfw_body_custom_page_size_height', $body_settings_arr ) ? $body_settings_arr['pgfw_body_custom_page_size_height'] : '';
+		$pgfw_body_custom_page_size_width  = array_key_exists( 'pgfw_body_custom_page_size_width', $body_settings_arr ) ? $body_settings_arr['pgfw_body_custom_page_size_width'] : '';
+		$pgfw_body_page_template           = array_key_exists( 'pgfw_body_page_template', $body_settings_arr ) ? $body_settings_arr['pgfw_body_page_template'] : 'template1';
+		$pgfw_body_post_template           = array_key_exists( 'pgfw_body_post_template', $body_settings_arr ) ? $body_settings_arr['pgfw_body_post_template'] : 'template1';
+		$pgfw_body_spcl_char_support       = array_key_exists( 'pgfw_body_spcl_char_support', $body_settings_arr ) ? $body_settings_arr['pgfw_body_spcl_char_support'] : '';
+		$post_id                           = is_array( $prod_id ) ? $prod_id[0] : $prod_id;
 		if ( 'preview' === $pgfw_generate_mode ) {
 			require_once $template;
 		} elseif ( 'page' === get_post_type( $post_id ) ) {
@@ -267,8 +267,8 @@ class Pdf_Generator_For_Wp_Common {
 			'11x17'                    => array( 0, 0, 792.00, 1224.00 ),
 		);
 
-		$upload_dir     = wp_upload_dir();
-		$html = mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' );
+		$upload_dir = wp_upload_dir();
+		$html       = mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' );
 			// Webp Image Start Fixes ///////////////////////////////////////////////////////////
 			// Load HTML content into DOMDocument.
 			$dom = new DOMDocument();
@@ -297,7 +297,7 @@ class Pdf_Generator_For_Wp_Common {
 				$parts = explode( '.', $src );
 
 				// Modify the content after the dot.
-				$extension = end( $parts );
+				$extension     = end( $parts );
 				$new_extension = 'jpeg';
 
 				$new_src = str_replace( '.' . $extension, '.' . $new_extension, $src );
@@ -307,7 +307,7 @@ class Pdf_Generator_For_Wp_Common {
 				// Save JPEG image with 100% quality.
 				imagejpeg( $webp_image, $jpeg_image_path, 100 );
 				$img_url = str_replace( $upload_dir['basedir'], $upload_dir['baseurl'], $jpeg_image_path );
-				$html = '<img src="' . $img_url . '" alt="Converted Image">';
+				$html    = '<img src="' . $img_url . '" alt="Converted Image">';
 
 				// Free up memory.
 				imagedestroy( $webp_image );
@@ -328,12 +328,12 @@ class Pdf_Generator_For_Wp_Common {
 				}
 			</style>';
 
-		if ( 'custom_page' == $body_page_size && ! empty( $pgfw_body_custom_page_size_width ) && ! empty( $pgfw_body_custom_page_size_height ) ) {
+		if ( 'custom_page' === $body_page_size && ! empty( $pgfw_body_custom_page_size_width ) && ! empty( $pgfw_body_custom_page_size_height ) ) {
 			$paper_size = array( 0, 0, $pgfw_body_custom_page_size_width * 2.834, $pgfw_body_custom_page_size_height * 2.834 );
 		} else {
 			$paper_size = array_key_exists( $body_page_size, $paper_sizes ) ? $paper_sizes[ $body_page_size ] : 'a4';
 		}
-		if ( 'yes' == $pgfw_meta_fields_show_unknown_image_format ) {
+		if ( 'yes' === $pgfw_meta_fields_show_unknown_image_format ) {
 			$options = new Options();
 			$options->set( 'isRemoteEnabled', true );
 			$options->set( 'isHtml5ParserEnabled', true );
@@ -342,8 +342,8 @@ class Pdf_Generator_For_Wp_Common {
 			$contxt = stream_context_create(
 				array(
 					'ssl' => array(
-						'verify_peer' => false,
-						'verify_peer_name' => false,
+						'verify_peer'       => false,
+						'verify_peer_name'  => false,
 						'allow_self_signed' => true,
 					),
 				)
@@ -362,7 +362,7 @@ class Pdf_Generator_For_Wp_Common {
 						'method'     => 'GET',
 						'user_agent' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
 					),
-					'ssl' => array(
+					'ssl'  => array(
 						'verify_peer'       => false,
 						'verify_peer_name'  => false,
 						'allow_self_signed' => true,
@@ -372,7 +372,7 @@ class Pdf_Generator_For_Wp_Common {
 
 			$dompdf->setHttpContext( $contxt );
 		}
-		//Relative Link to Absolute link.
+		// Relative Link to Absolute link.
 		$site_url = trailingslashit( get_site_url() );
 		$dompdf->setBasePath( $site_url );
 		$html = preg_replace(
@@ -392,14 +392,14 @@ class Pdf_Generator_For_Wp_Common {
 		if ( 'yes' === $body_add_watermark ) {
 			$options = new Options();
 			$options->set( 'isPhpEnabled', 'true' );
-			$canvas       = $dompdf->getCanvas();
-			$fontmetrices = new FontMetrics( $canvas, $options );
-			$w            = $canvas->get_width();
-			$h            = $canvas->get_height();
-			$font         = $fontmetrices->getFont( 'times' );
-			$text         = $body_watermark_text;
-			$textheight   = $fontmetrices->getFontHeight( $font, 150 );
-			$textwidth    = $fontmetrices->getTextWidth( $text, $font, 40 );
+			$canvas          = $dompdf->getCanvas();
+			$fontmetrices    = new FontMetrics( $canvas, $options );
+			$w               = $canvas->get_width();
+			$h               = $canvas->get_height();
+			$font            = $fontmetrices->getFont( 'times' );
+			$text            = $body_watermark_text;
+			$textheight      = $fontmetrices->getFontHeight( $font, 150 );
+			$textwidth       = $fontmetrices->getTextWidth( $text, $font, 40 );
 			$x               = ( ( $w - $textwidth ) / 2 );
 			$y               = ( ( $h - $textheight ) / 2 );
 			$hex             = $body_watermark_color;
@@ -407,8 +407,8 @@ class Pdf_Generator_For_Wp_Common {
 
 		}
 
-		if ( 'yes' == $pgfw_general_pdf_show_pageno ) {
-			$canvas       = $dompdf->getCanvas();
+		if ( 'yes' === $pgfw_general_pdf_show_pageno ) {
+			$canvas = $dompdf->getCanvas();
 			if ( ! empty( $pgfw_pageno_position_left ) && ! empty( $pgfw_pageno_position_top ) ) {
 				$canvas->page_text( $pgfw_pageno_position_left, $pgfw_pageno_position_top, '{PAGE_NUM}/{PAGE_COUNT}', $font, 8, array( 0, 0, 0 ) );
 			} else {
@@ -522,14 +522,14 @@ class Pdf_Generator_For_Wp_Common {
 	 */
 	public function pgfw_aspose_pdf_exporter_bulk_action() {
 		require_once PDF_GENERATOR_FOR_WP_DIR_PATH . 'package/lib/dompdf/vendor/autoload.php';
-		$general_settings_arr = get_option( 'pgfw_general_settings_save', array() );
-		$pgfw_generate_mode   = array_key_exists( 'pgfw_general_pdf_generate_mode', $general_settings_arr ) ? $general_settings_arr['pgfw_general_pdf_generate_mode'] : 'download_locally';
-		$body_settings_arr       = get_option( 'pgfw_body_save_settings', array() );
-		$pgfw_body_custom_page_size_height        = array_key_exists( 'pgfw_body_custom_page_size_height', $body_settings_arr ) ? $body_settings_arr['pgfw_body_custom_page_size_height'] : '';
-		$pgfw_body_custom_page_size_width        = array_key_exists( 'pgfw_body_custom_page_size_width', $body_settings_arr ) ? $body_settings_arr['pgfw_body_custom_page_size_width'] : '';
-		$page_orientation     = array_key_exists( 'pgfw_body_page_orientation', $body_settings_arr ) ? $body_settings_arr['pgfw_body_page_orientation'] : 'portrait';
-		$body_page_size       = array_key_exists( 'pgfw_body_page_size', $body_settings_arr ) ? $body_settings_arr['pgfw_body_page_size'] : 'a4';
-		$paper_sizes = array(
+		$general_settings_arr              = get_option( 'pgfw_general_settings_save', array() );
+		$pgfw_generate_mode                = array_key_exists( 'pgfw_general_pdf_generate_mode', $general_settings_arr ) ? $general_settings_arr['pgfw_general_pdf_generate_mode'] : 'download_locally';
+		$body_settings_arr                 = get_option( 'pgfw_body_save_settings', array() );
+		$pgfw_body_custom_page_size_height = array_key_exists( 'pgfw_body_custom_page_size_height', $body_settings_arr ) ? $body_settings_arr['pgfw_body_custom_page_size_height'] : '';
+		$pgfw_body_custom_page_size_width  = array_key_exists( 'pgfw_body_custom_page_size_width', $body_settings_arr ) ? $body_settings_arr['pgfw_body_custom_page_size_width'] : '';
+		$page_orientation                  = array_key_exists( 'pgfw_body_page_orientation', $body_settings_arr ) ? $body_settings_arr['pgfw_body_page_orientation'] : 'portrait';
+		$body_page_size                    = array_key_exists( 'pgfw_body_page_size', $body_settings_arr ) ? $body_settings_arr['pgfw_body_page_size'] : 'a4';
+		$paper_sizes                       = array(
 			'4a0'                      => array( 0, 0, 4767.87, 6740.79 ),
 			'2a0'                      => array( 0, 0, 3370.39, 4767.87 ),
 			'a0'                       => array( 0, 0, 2383.94, 3370.39 ),
@@ -575,27 +575,27 @@ class Pdf_Generator_For_Wp_Common {
 			'8.5x14'                   => array( 0, 0, 612.00, 1008.0 ),
 			'11x17'                    => array( 0, 0, 792.00, 1224.00 ),
 		);
-		if ( 'custom_page' == $body_page_size && ! empty( $pgfw_body_custom_page_size_width ) && ! empty( $pgfw_body_custom_page_size_height ) ) {
+		if ( 'custom_page' === $body_page_size && ! empty( $pgfw_body_custom_page_size_width ) && ! empty( $pgfw_body_custom_page_size_height ) ) {
 			$paper_size = array( 0, 0, $pgfw_body_custom_page_size_width * 2.834, $pgfw_body_custom_page_size_height * 2.834 );
 		} else {
 			$paper_size = array_key_exists( $body_page_size, $paper_sizes ) ? $paper_sizes[ $body_page_size ] : 'a4';
 		}
-		$upload_dir = wp_upload_dir();
+		$upload_dir  = wp_upload_dir();
 		$upload_path = $upload_dir['path'] . '/';
 
 		$html_file = $upload_path . 'outpuut.html';
-		$pdf_file = $upload_path . 'outpuut.pdf';
+		$pdf_file  = $upload_path . 'outpuut.pdf';
 
 		global $typenow;
 		$post_type = $typenow;
 
 		// get the action.
 		$wp_list_table = _get_list_table( 'WP_Posts_List_Table' );  // depending on your resource type this could be WP_Users_List_Table, WP_Comments_List_Table, etc.
-		$action = $wp_list_table->current_action();
+		$action        = $wp_list_table->current_action();
 
 		$allowed_actions = array( 'export' );
 
-		if ( ! in_array( $action, $allowed_actions ) ) {
+		if ( ! in_array( $action, $allowed_actions, true ) ) {
 			return;
 		}
 
@@ -624,12 +624,12 @@ class Pdf_Generator_For_Wp_Common {
 
 		switch ( $action ) {
 			case 'export':
-				$exported = count( $post_ids );
+				$exported  = count( $post_ids );
 				$file_name = '';
 				if ( is_array( $post_ids ) && count( $post_ids ) > 0 ) {
-					$file_name1 = $this->pgfw_aspose_pdf_exporter_array_to_html( $post_ids );
+					$file_name1    = $this->pgfw_aspose_pdf_exporter_array_to_html( $post_ids );
 					$template_name = apply_filters( 'wps_pgfw_product_post_ids_in_pdf_filter_hook', $file_name1, $post_ids );
-					if ( 'template1' == $template_name ) {
+					if ( 'template1' === $template_name ) {
 						$file_name .= apply_filters( 'wps_pgfw_add_cover_page_template_to_bulk_pdf', $html );
 						$file_name .= $this->pgfw_aspose_pdf_exporter_array_to_html( $post_ids );
 					} else {
@@ -647,7 +647,7 @@ class Pdf_Generator_For_Wp_Common {
 								'method'     => 'GET',
 								'user_agent' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
 							),
-							'ssl' => array(
+							'ssl'  => array(
 								'verify_peer'       => false,
 								'verify_peer_name'  => false,
 								'allow_self_signed' => true,
@@ -719,11 +719,11 @@ class Pdf_Generator_For_Wp_Common {
 	 */
 	public function pgfw_aspose_pdf_exporter_array_to_html( $post_ids ) {
 
-		$ids = $post_ids;
+		$ids                     = $post_ids;
 		$body_settings_arr       = get_option( 'pgfw_body_save_settings', array() );
 		$pgfw_body_page_template = array_key_exists( 'pgfw_body_page_template', $body_settings_arr ) ? $body_settings_arr['pgfw_body_page_template'] : 'template1';
 		$pgfw_body_post_template = array_key_exists( 'pgfw_body_post_template', $body_settings_arr ) ? $body_settings_arr['pgfw_body_post_template'] : 'template1';
-		$template_file_name = PDF_GENERATOR_FOR_WP_DIR_PATH . 'common/templates/bulk-pdf-template.php';
+		$template_file_name      = PDF_GENERATOR_FOR_WP_DIR_PATH . 'common/templates/bulk-pdf-template.php';
 		require_once $template_file_name;
 		return bulk_pdf_exporter_html( $ids );
 	}
@@ -756,13 +756,13 @@ class Pdf_Generator_For_Wp_Common {
 		$prefix = get_option( 'wpg_invoice_number_prefix' );
 		$suffix = get_option( 'wpg_invoice_number_suffix' );
 		$digit  = ( $digit ) ? $digit : 4;
-		$order = wc_get_order( $order_id );
+		$order  = wc_get_order( $order_id );
 		// get_post_meta.
 		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			// HPOS usage is enabled.
 			$in_id = $order->get_meta( 'wpg_order_invoice_id', true );
 		} else {
-			$in_id  = get_post_meta( $order_id, 'wpg_order_invoice_id', true );
+			$in_id = get_post_meta( $order_id, 'wpg_order_invoice_id', true );
 		}
 		if ( $in_id ) {
 			$invoice_id = $in_id;
@@ -863,14 +863,14 @@ class Pdf_Generator_For_Wp_Common {
 			}
 			if ( 'one' === $template ) {
 				$template_path = PDF_GENERATOR_FOR_WP_DIR_PATH . 'admin/partials/pdf_templates/pdf-generator-for-wp-invoice-pdflayout1.php';
-			} else if ( 'two' === $template ) {
+			} elseif ( 'two' === $template ) {
 				$template_path = PDF_GENERATOR_FOR_WP_DIR_PATH . 'admin/partials/pdf_templates/pdf-generator-for-wp-invoice-pdflayout2.php';
-			} else if ( 'three' === $template ) {
+			} elseif ( 'three' === $template ) {
 				$template_path = PDF_GENERATOR_FOR_WP_DIR_PATH . 'admin/partials/pdf_templates/pdf-generator-for-wp-invoice-pdflayout3.php';
 			}
 			$template_path = apply_filters( 'wpg_load_template_for_invoice_generation', $template_path );
 			require_once $template_path;
-			$html   = return_ob_value( $order_id, $type, $invoice_id );
+			$html = return_ob_value( $order_id, $type, $invoice_id );
 
 			$dompdf = new Dompdf( array( 'enable_remote' => true ) );
 
@@ -900,7 +900,7 @@ class Pdf_Generator_For_Wp_Common {
 					$parts = explode( '.', $src );
 
 					// Modify the content after the dot.
-					$extension = end( $parts );
+					$extension     = end( $parts );
 					$new_extension = 'jpeg';
 
 					$new_src = str_replace( '.' . $extension, '.' . $new_extension, $src );
@@ -910,7 +910,7 @@ class Pdf_Generator_For_Wp_Common {
 					// Save JPEG image with 100% quality.
 					imagejpeg( $webp_image, $jpeg_image_path, 100 );
 					$img_url = str_replace( $upload_dir['basedir'], $upload_dir['baseurl'], $jpeg_image_path );
-					$html = '<img src="' . $img_url . '" alt="Converted Image">';
+					$html    = '<img src="' . $img_url . '" alt="Converted Image">';
 
 					// Free up memory.
 					imagedestroy( $webp_image );
@@ -1067,12 +1067,12 @@ class Pdf_Generator_For_Wp_Common {
 				'tax_totals'         => ( $tax_total ) ? number_format( $tax_total, $decimals, $decimal_separator, $thousand_separator ) : 0,
 				'order_created_date' => $order->get_date_created()->format( get_option( 'date_format', 'd-m-Y' ) ),
 			);
-			$payment = $order->get_checkout_payment_url();
+			$payment                 = $order->get_checkout_payment_url();
 			$order_details_arr       = array(
 				'shipping_details' => $shipping_details,
 				'billing_details'  => $billing_details,
 				'product_details'  => $order_product_details,
-				'payment_url' => $payment,
+				'payment_url'      => $payment,
 			);
 			return wp_json_encode( $order_details_arr );
 		}
@@ -1089,23 +1089,23 @@ class Pdf_Generator_For_Wp_Common {
 	public function cron_job_wpg_common_generate_pdf( $prod_id, $type, $action ) {
 
 		require_once PDF_GENERATOR_FOR_WP_DIR_PATH . 'package/lib/dompdf/vendor/autoload.php';
-		$upload_dir                       = wp_upload_dir();
-		$upload_basedir                   = $upload_dir['basedir'] . '/bulk_pdf/';
-		$path                             = $upload_basedir . get_the_title( $prod_id ) . '.pdf';
-		$file_url                         = $upload_dir['baseurl'] . '/bulk_pdf/' . get_the_title( $prod_id ) . '.pdf';
-		$body_settings_arr       = get_option( 'pgfw_body_save_settings', array() );
-		$pgfw_body_custom_page_size_height        = array_key_exists( 'pgfw_body_custom_page_size_height', $body_settings_arr ) ? $body_settings_arr['pgfw_body_custom_page_size_height'] : '';
-		$pgfw_body_custom_page_size_width        = array_key_exists( 'pgfw_body_custom_page_size_width', $body_settings_arr ) ? $body_settings_arr['pgfw_body_custom_page_size_width'] : '';
-		$pgfw_body_page_template = array_key_exists( 'pgfw_body_page_template', $body_settings_arr ) ? $body_settings_arr['pgfw_body_page_template'] : 'template1';
-		$pgfw_body_post_template = array_key_exists( 'pgfw_body_post_template', $body_settings_arr ) ? $body_settings_arr['pgfw_body_post_template'] : 'template1';
-		$general_settings_arr = get_option( 'pgfw_general_settings_save', array() );
-		$pdf_file_name        = array_key_exists( 'pgfw_general_pdf_file_name', $general_settings_arr ) ? $general_settings_arr['pgfw_general_pdf_file_name'] : 'post_name';
-		$body_add_watermark   = array_key_exists( 'pgfw_body_add_watermark', $body_settings_arr ) ? $body_settings_arr['pgfw_body_add_watermark'] : '#000000';
-		$body_watermark_color = array_key_exists( 'pgfw_body_watermark_color', $body_settings_arr ) ? $body_settings_arr['pgfw_body_watermark_color'] : '';
-		$body_watermark_text  = array_key_exists( 'pgfw_body_watermark_text', $body_settings_arr ) ? $body_settings_arr['pgfw_body_watermark_text'] : '';
-		$body_page_size       = array_key_exists( 'pgfw_body_page_size', $body_settings_arr ) ? $body_settings_arr['pgfw_body_page_size'] : 'a4';
-		$page_orientation     = array_key_exists( 'pgfw_body_page_orientation', $body_settings_arr ) ? $body_settings_arr['pgfw_body_page_orientation'] : 'portrait';
-		$document_name        = '';
+		$upload_dir                        = wp_upload_dir();
+		$upload_basedir                    = $upload_dir['basedir'] . '/bulk_pdf/';
+		$path                              = $upload_basedir . get_the_title( $prod_id ) . '.pdf';
+		$file_url                          = $upload_dir['baseurl'] . '/bulk_pdf/' . get_the_title( $prod_id ) . '.pdf';
+		$body_settings_arr                 = get_option( 'pgfw_body_save_settings', array() );
+		$pgfw_body_custom_page_size_height = array_key_exists( 'pgfw_body_custom_page_size_height', $body_settings_arr ) ? $body_settings_arr['pgfw_body_custom_page_size_height'] : '';
+		$pgfw_body_custom_page_size_width  = array_key_exists( 'pgfw_body_custom_page_size_width', $body_settings_arr ) ? $body_settings_arr['pgfw_body_custom_page_size_width'] : '';
+		$pgfw_body_page_template           = array_key_exists( 'pgfw_body_page_template', $body_settings_arr ) ? $body_settings_arr['pgfw_body_page_template'] : 'template1';
+		$pgfw_body_post_template           = array_key_exists( 'pgfw_body_post_template', $body_settings_arr ) ? $body_settings_arr['pgfw_body_post_template'] : 'template1';
+		$general_settings_arr              = get_option( 'pgfw_general_settings_save', array() );
+		$pdf_file_name                     = array_key_exists( 'pgfw_general_pdf_file_name', $general_settings_arr ) ? $general_settings_arr['pgfw_general_pdf_file_name'] : 'post_name';
+		$body_add_watermark                = array_key_exists( 'pgfw_body_add_watermark', $body_settings_arr ) ? $body_settings_arr['pgfw_body_add_watermark'] : '#000000';
+		$body_watermark_color              = array_key_exists( 'pgfw_body_watermark_color', $body_settings_arr ) ? $body_settings_arr['pgfw_body_watermark_color'] : '';
+		$body_watermark_text               = array_key_exists( 'pgfw_body_watermark_text', $body_settings_arr ) ? $body_settings_arr['pgfw_body_watermark_text'] : '';
+		$body_page_size                    = array_key_exists( 'pgfw_body_page_size', $body_settings_arr ) ? $body_settings_arr['pgfw_body_page_size'] : 'a4';
+		$page_orientation                  = array_key_exists( 'pgfw_body_page_orientation', $body_settings_arr ) ? $body_settings_arr['pgfw_body_page_orientation'] : 'portrait';
+		$document_name                     = '';
 
 		if ( 'page' === get_post_type( $prod_id ) ) {
 			$template_file_name = PDF_GENERATOR_FOR_WP_DIR_PATH . 'admin/partials/pdf_templates/pdf-generator-for-wp-admin-' . $pgfw_body_page_template . '.php';
@@ -1117,7 +1117,7 @@ class Pdf_Generator_For_Wp_Common {
 			require_once $template_file_name;
 		}
 
-		$post                 = get_post( $prod_id );
+		$post = get_post( $prod_id );
 		if ( 'custom' === $pdf_file_name ) {
 			$pdf_file_name_custom = array_key_exists( 'pgfw_custom_pdf_file_name', $general_settings_arr ) ? $general_settings_arr['pgfw_custom_pdf_file_name'] : '';
 			$document_name        = ( ( '' !== $pdf_file_name_custom ) && ( $post ) ) ? $pdf_file_name_custom . '_' . $post->ID : 'document';
@@ -1128,7 +1128,7 @@ class Pdf_Generator_For_Wp_Common {
 		}
 
 		$html  = '';
-		$html  .= apply_filters( 'wps_pgfw_add_cover_page_template_to_single_pdf', $html );
+		$html .= apply_filters( 'wps_pgfw_add_cover_page_template_to_single_pdf', $html );
 		$html .= return_ob_html( $prod_id, $template = '' );
 
 		$dompdf = new Dompdf( array( 'enable_remote' => true ) );
@@ -1159,7 +1159,7 @@ class Pdf_Generator_For_Wp_Common {
 				$parts = explode( '.', $src );
 
 				// Modify the content after the dot.
-				$extension = end( $parts );
+				$extension     = end( $parts );
 				$new_extension = 'jpeg';
 
 				$new_src = str_replace( '.' . $extension, '.' . $new_extension, $src );
@@ -1169,7 +1169,7 @@ class Pdf_Generator_For_Wp_Common {
 				// Save JPEG image with 100% quality.
 				imagejpeg( $webp_image, $jpeg_image_path, 100 );
 				$img_url = str_replace( $upload_dir['basedir'], $upload_dir['baseurl'], $jpeg_image_path );
-				$html = '<img src="' . $img_url . '" alt="Converted Image">';
+				$html    = '<img src="' . $img_url . '" alt="Converted Image">';
 
 				// Free up memory.
 				imagedestroy( $webp_image );

--- a/common/templates/bulk-pdf-template.php
+++ b/common/templates/bulk-pdf-template.php
@@ -24,14 +24,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @return string
  */
-function bulk_pdf_exporter_html( $post_ids, $template_name = '' ) {
+function bulk_pdf_exporter_html( $post_ids, $template_name = '' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- $template_name is kept for template-selection API compatibility.
 
 	do_action( 'wps_pgfw_load_all_compatible_shortcode_converter' );
-	$pgfw_display_settings                   = get_option( 'pgfw_save_admin_display_settings', array() );
+	$pgfw_display_settings = get_option( 'pgfw_save_admin_display_settings', array() );
 	// advanced settings.
-	$pgfw_advanced_settings = get_option( 'pgfw_advanced_save_settings', array() );
-	$pgfw_ttf_font_upload   = array_key_exists( 'pgfw_ttf_font_upload', $pgfw_advanced_settings ) ? $pgfw_advanced_settings['pgfw_ttf_font_upload'] : '';
-	$pgfw_template_color_option                 = array_key_exists( 'pgfw_template_color_option', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_color_option'] : '';
+	$pgfw_advanced_settings     = get_option( 'pgfw_advanced_save_settings', array() );
+	$pgfw_ttf_font_upload       = array_key_exists( 'pgfw_ttf_font_upload', $pgfw_advanced_settings ) ? $pgfw_advanced_settings['pgfw_ttf_font_upload'] : '';
+	$pgfw_template_color_option = array_key_exists( 'pgfw_template_color_option', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_color_option'] : '';
 	// header customisation settings.
 	$pgfw_header_settings   = get_option( 'pgfw_header_setting_submit', array() );
 	$pgfw_header_use_in_pdf = array_key_exists( 'pgfw_header_use_in_pdf', $pgfw_header_settings ) ? $pgfw_header_settings['pgfw_header_use_in_pdf'] : '';
@@ -68,10 +68,10 @@ function bulk_pdf_exporter_html( $post_ids, $template_name = '' ) {
 	$pgfw_border_position_right      = array_key_exists( 'pgfw_border_position_right', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_border_position_right'] : '';
 	$pgfw_body_custom_css            = array_key_exists( 'pgfw_body_custom_css', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_custom_css'] : '';
 	$pgfw_body_watermark_text        = array_key_exists( 'pgfw_body_watermark_text', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_watermark_text'] : '';
-	$pgfw_body_add_watermark        = array_key_exists( 'pgfw_body_add_watermark', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_add_watermark'] : '';
-	$pgfw_body_watermark_color        = array_key_exists( 'pgfw_body_watermark_color', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_watermark_color'] : '';
-	$pgfw_template_color               = array_key_exists( 'pgfw_template_color', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_color'] : '#FFFFFF';
-	$pgfw_template_text_color       = array_key_exists( 'pgfw_template_text_color', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_text_color'] : '#000000';
+	$pgfw_body_add_watermark         = array_key_exists( 'pgfw_body_add_watermark', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_add_watermark'] : '';
+	$pgfw_body_watermark_color       = array_key_exists( 'pgfw_body_watermark_color', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_watermark_color'] : '';
+	$pgfw_template_color             = array_key_exists( 'pgfw_template_color', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_color'] : '#FFFFFF';
+	$pgfw_template_text_color        = array_key_exists( 'pgfw_template_text_color', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_template_text_color'] : '#000000';
 	// general settings.
 	$general_settings_data     = get_option( 'pgfw_general_settings_save', array() );
 	$pgfw_show_post_categories = array_key_exists( 'pgfw_general_pdf_show_categories', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_show_categories'] : '';
@@ -82,32 +82,32 @@ function bulk_pdf_exporter_html( $post_ids, $template_name = '' ) {
 	// meta fields settings.
 	$pgfw_meta_settings = get_option( 'pgfw_meta_fields_save_settings', array() );
 	// footer settings.
-	$pgfw_footer_settings   = get_option( 'pgfw_footer_setting_submit', array() );
-	$pgfw_footer_use_in_pdf = array_key_exists( 'pgfw_footer_use_in_pdf', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_use_in_pdf'] : '';
-	$pgfw_footer_tagline    = array_key_exists( 'pgfw_footer_tagline', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_tagline'] : '';
-	$pgfw_footer_color      = array_key_exists( 'pgfw_footer_color', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_color'] : '';
-	$pgfw_footer_width      = array_key_exists( 'pgfw_footer_width', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_width'] : '';
-	$pgfw_footer_font_style = array_key_exists( 'pgfw_footer_font_style', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_font_style'] : '';
-	$pgfw_footer_font_style = ( 'custom' === $pgfw_footer_font_style ) ? 'My_font' : $pgfw_footer_font_style;
-	$pgfw_footer_font_size  = array_key_exists( 'pgfw_footer_font_size', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_font_size'] : '';
-	$pgfw_footer_bottom     = array_key_exists( 'pgfw_footer_bottom', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_bottom'] : '';
-	$pgfw_footer_customization     = array_key_exists( 'pgfw_footer_customization_for_post_detail', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_customization_for_post_detail'] : '';
-	$pgfw_body_meta_field_column     = array_key_exists( 'pgfw_body_meta_field_column', $pgfw_body_settings ) ? intval( $pgfw_body_settings['pgfw_body_meta_field_column'] ) : '';
-	$status  = get_option( 'status' );
+	$pgfw_footer_settings        = get_option( 'pgfw_footer_setting_submit', array() );
+	$pgfw_footer_use_in_pdf      = array_key_exists( 'pgfw_footer_use_in_pdf', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_use_in_pdf'] : '';
+	$pgfw_footer_tagline         = array_key_exists( 'pgfw_footer_tagline', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_tagline'] : '';
+	$pgfw_footer_color           = array_key_exists( 'pgfw_footer_color', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_color'] : '';
+	$pgfw_footer_width           = array_key_exists( 'pgfw_footer_width', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_width'] : '';
+	$pgfw_footer_font_style      = array_key_exists( 'pgfw_footer_font_style', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_font_style'] : '';
+	$pgfw_footer_font_style      = ( 'custom' === $pgfw_footer_font_style ) ? 'My_font' : $pgfw_footer_font_style;
+	$pgfw_footer_font_size       = array_key_exists( 'pgfw_footer_font_size', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_font_size'] : '';
+	$pgfw_footer_bottom          = array_key_exists( 'pgfw_footer_bottom', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_bottom'] : '';
+	$pgfw_footer_customization   = array_key_exists( 'pgfw_footer_customization_for_post_detail', $pgfw_footer_settings ) ? $pgfw_footer_settings['pgfw_footer_customization_for_post_detail'] : '';
+	$pgfw_body_meta_field_column = array_key_exists( 'pgfw_body_meta_field_column', $pgfw_body_settings ) ? intval( $pgfw_body_settings['pgfw_body_meta_field_column'] ) : '';
+	$status                      = get_option( 'status' );
 
-	if ( '' == $pgfw_footer_customization ) {
+	if ( '' === $pgfw_footer_customization ) {
 		$pgfw_footer_customization = array();
 	}
-	if ( '' == $status ) {
-		$post = get_post( $post_id );
-		$author_id = get_post_field( 'post_author', $post_id );
+	if ( empty( $status ) ) {
+		$post         = get_post( $post_id );
+		$author_id    = get_post_field( 'post_author', $post_id );
 		$display_name = get_the_author_meta( 'display_name', $author_id );
-		$post_date = get_the_date( 'd F Y', $post_id );
-		$post_title = get_the_title( $post );
+		$post_date    = get_the_date( 'd F Y', $post_id );
+		$post_title   = get_the_title( $post );
 	}
-		$display_author_name = in_array( 'author', $pgfw_footer_customization ) ? $display_name : '';
-		$display_post_date = in_array( 'post_date', $pgfw_footer_customization ) ? $post_date : '';
-		$display_post_title = in_array( 'post_title', $pgfw_footer_customization ) ? $post_title : '';
+		$display_author_name = in_array( 'author', $pgfw_footer_customization, true ) ? $display_name : '';
+		$display_post_date   = in_array( 'post_date', $pgfw_footer_customization, true ) ? $post_date : '';
+		$display_post_title  = in_array( 'post_title', $pgfw_footer_customization, true ) ? $post_title : '';
 	if ( 'yes' === $pgfw_body_rtl_support ) {
 		$pgfw_header_font_style     = 'DejaVu Sans, sans-serif';
 		$pgfw_body_page_font_style  = 'DejaVu Sans, sans-serif';
@@ -160,7 +160,7 @@ function bulk_pdf_exporter_html( $post_ids, $template_name = '' ) {
 		</style>
 		<div class="pgfw-border-page" ></div>';
 	}
-	if ( 'yes' == $pgfw_body_add_watermark ) {
+	if ( 'yes' === $pgfw_body_add_watermark ) {
 		$watermark = $pgfw_body_watermark_text;
 	} else {
 		$watermark = '';
@@ -259,7 +259,7 @@ function bulk_pdf_exporter_html( $post_ids, $template_name = '' ) {
 
 	foreach ( $post_ids as $post_id ) {
 
-		if ( 'yes' == $pgfw_watermark_image_use_in_pdf ) {
+		if ( 'yes' === $pgfw_watermark_image_use_in_pdf ) {
 			$html = apply_filters( 'pgfw_customize_body_watermark_image_pdf', $html );
 		}
 		if ( '' !== $pgfw_body_custom_css ) {
@@ -290,7 +290,7 @@ function bulk_pdf_exporter_html( $post_ids, $template_name = '' ) {
 						
 					}';
 
-			if ( 'yes' == $pgfw_template_color_option ) {
+			if ( 'yes' === $pgfw_template_color_option ) {
 				$html .= '
 						.pgfw-pdf-body {
 							position: fixed;
@@ -423,35 +423,35 @@ function bulk_pdf_exporter_html( $post_ids, $template_name = '' ) {
 				$html       .= '<div>' . $author_name . '</div>';
 			}
 			// meta fields.
-			$post_type               = $post->post_type;
-			$pgfw_show_type_meta_val = array_key_exists( 'pgfw_meta_fields_' . $post_type . '_show', $pgfw_meta_settings ) ? $pgfw_meta_settings[ 'pgfw_meta_fields_' . $post_type . '_show' ] : '';
-			$pgfw_show_type_meta_arr = array_key_exists( 'pgfw_meta_fields_' . $post_type . '_list', $pgfw_meta_settings ) ? $pgfw_meta_settings[ 'pgfw_meta_fields_' . $post_type . '_list' ] : array();
-			$pgfw_body_metafields_row_wise     = array_key_exists( 'pgfw_body_metafields_row_wise', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_metafields_row_wise'] : '';
-			$html2                   = '';
+			$post_type                     = $post->post_type;
+			$pgfw_show_type_meta_val       = array_key_exists( 'pgfw_meta_fields_' . $post_type . '_show', $pgfw_meta_settings ) ? $pgfw_meta_settings[ 'pgfw_meta_fields_' . $post_type . '_show' ] : '';
+			$pgfw_show_type_meta_arr       = array_key_exists( 'pgfw_meta_fields_' . $post_type . '_list', $pgfw_meta_settings ) ? $pgfw_meta_settings[ 'pgfw_meta_fields_' . $post_type . '_list' ] : array();
+			$pgfw_body_metafields_row_wise = array_key_exists( 'pgfw_body_metafields_row_wise', $pgfw_body_settings ) ? $pgfw_body_settings['pgfw_body_metafields_row_wise'] : '';
+			$html2                         = '';
 			if ( 'yes' === $pgfw_show_type_meta_val ) {
 				if ( is_array( $pgfw_show_type_meta_arr ) ) {
 					$html2 .= '<div><b>' . __( 'Meta Fields', 'pdf-generator-for-wp' ) . '</b></div>';
 					$html2 .= '<table><tr>';
 					foreach ( $pgfw_show_type_meta_arr as $meta_key ) {
-						$meta_val          = get_post_meta( $post->ID, $meta_key, true );
+						$meta_val           = get_post_meta( $post->ID, $meta_key, true );
 						$pgfw_meta_key_name = ucwords( str_replace( '_', ' ', $meta_key ) );
 						if ( $meta_val ) {
-							if ( '_product_image_gallery' == $meta_key ) {
+							if ( '_product_image_gallery' === $meta_key ) {
 
 								$meta_val1 = explode( ',', $meta_val );
 								foreach ( $meta_val1 as $key => $val ) {
 
 									$thumbnail_url = get_the_guid( $val );
-									$thumbnail = '<img  src=' . $thumbnail_url . ' alt="post thumbnail" style="height:100px; width: 100px; margin:17px;" height=50 weight=50/>';
-									$html2 .= $thumbnail;
+									$thumbnail     = '<img  src=' . $thumbnail_url . ' alt="post thumbnail" style="height:100px; width: 100px; margin:17px;" height=50 weight=50/>';
+									$html2        .= $thumbnail;
 								}
 								$html2 .= '<div><b> ' . $pgfw_meta_key_name . '</b> </div>';
 
-							} elseif ( 'yes' == $pgfw_body_metafields_row_wise ) {
-									$i++;
+							} elseif ( 'yes' === $pgfw_body_metafields_row_wise ) {
+									++$i;
 									$html2 .= '<td><b>' . $pgfw_meta_key_name . ' :</b></td>';
 									$html2 .= '<td> ' . $meta_val . ' </td>';
-								if ( 0 == $i % $pgfw_body_meta_field_column ) {
+								if ( 0 === $i % $pgfw_body_meta_field_column ) {
 									$html2 .= '</tr><tr>';
 								}
 							} else {

--- a/includes/class-pdf-generator-for-wp-onboarding-steps.php
+++ b/includes/class-pdf-generator-for-wp-onboarding-steps.php
@@ -163,7 +163,7 @@ class Pdf_Generator_For_Wp_Onboarding_Steps {
 	public function wps_pgfw_onboarding_enqueue_styles() {
 		global $pagenow;
 		$asset_version = defined( 'PDF_GENERATOR_FOR_WP_VERSION' ) ? PDF_GENERATOR_FOR_WP_VERSION : '1.6.2';
-		$is_valid = false;
+		$is_valid      = false;
 		if ( ! $is_valid && 'plugins.php' == $pagenow ) { // phpcs:ignore
 			$is_valid = true;
 		}
@@ -195,7 +195,7 @@ class Pdf_Generator_For_Wp_Onboarding_Steps {
 	public function wps_pgfw_onboarding_enqueue_scripts() {
 		global $pagenow;
 		$asset_version = defined( 'PDF_GENERATOR_FOR_WP_VERSION' ) ? PDF_GENERATOR_FOR_WP_VERSION : '1.6.2';
-		$is_valid = false;
+		$is_valid      = false;
 		if ( ! $is_valid && 'plugins.php' == $pagenow ) { // phpcs:ignore
 			$is_valid = true;
 		}

--- a/includes/class-pdf-generator-for-wp-talk-to-expert-form.php
+++ b/includes/class-pdf-generator-for-wp-talk-to-expert-form.php
@@ -156,46 +156,46 @@ class Pdf_Generator_For_Wp_Talk_To_Expert_Form {
 	 */
 	private function wps_pgfw_get_custom_form_fields() {
 		return array(
-			'firstname' => array(
+			'firstname'                           => array(
 				'label'       => esc_html__( 'First Name', 'pdf-generator-for-wp' ),
 				'type'        => 'text',
 				'placeholder' => esc_html__( 'John', 'pdf-generator-for-wp' ),
 				'required'    => false,
 			),
-			'lastname'  => array(
+			'lastname'                            => array(
 				'label'       => esc_html__( 'Last Name', 'pdf-generator-for-wp' ),
 				'type'        => 'text',
 				'placeholder' => esc_html__( 'Doe', 'pdf-generator-for-wp' ),
 				'required'    => false,
 			),
-			'email'      => array(
+			'email'                               => array(
 				'label'       => esc_html__( 'Work Email', 'pdf-generator-for-wp' ),
 				'type'        => 'email',
 				'placeholder' => esc_html__( 'name@company.com', 'pdf-generator-for-wp' ),
 				'required'    => true,
 				'full_width'  => true,
 			),
-			'phone'      => array(
+			'phone'                               => array(
 				'label'       => esc_html__( 'Contact Number', 'pdf-generator-for-wp' ),
 				'type'        => 'text',
 				'placeholder' => esc_html__( '+1 000 000 0000', 'pdf-generator-for-wp' ),
 				'required'    => false,
 			),
 			'what_services_do_you_need_help_with' => array(
-				'label'       => esc_html__( 'What services do you need help with?', 'pdf-generator-for-wp' ),
-				'type'        => 'checkbox_group',
-				'options'     => $this->wps_pgfw_get_talk_to_expert_service_options(),
-				'required'    => false,
-				'full_width'  => true,
+				'label'      => esc_html__( 'What services do you need help with?', 'pdf-generator-for-wp' ),
+				'type'       => 'checkbox_group',
+				'options'    => $this->wps_pgfw_get_talk_to_expert_service_options(),
+				'required'   => false,
+				'full_width' => true,
 			),
-			'budget'      => array(
-				'label'       => esc_html__( 'Budget', 'pdf-generator-for-wp' ),
-				'type'        => 'select',
-				'options'     => $this->wps_pgfw_get_talk_to_expert_budget_options(),
-				'required'    => false,
-				'full_width'  => true,
+			'budget'                              => array(
+				'label'      => esc_html__( 'Budget', 'pdf-generator-for-wp' ),
+				'type'       => 'select',
+				'options'    => $this->wps_pgfw_get_talk_to_expert_budget_options(),
+				'required'   => false,
+				'full_width' => true,
 			),
-			'message'    => array(
+			'message'                             => array(
 				'label'       => esc_html__( 'What do you need help with?', 'pdf-generator-for-wp' ),
 				'type'        => 'textarea',
 				'placeholder' => esc_html__( 'Share your goals, blockers, or the service you need.', 'pdf-generator-for-wp' ),
@@ -213,9 +213,9 @@ class Pdf_Generator_For_Wp_Talk_To_Expert_Form {
 	 * @param array  $values    Default values.
 	 */
 	private function wps_pgfw_render_form_field( $field_key, $field, $values ) {
-		$field_id = $field_key;
-		$field_value = isset( $values[ $field_key ] ) ? $values[ $field_key ] : '';
-		$field_class = ! empty( $field['full_width'] ) ? ' pgfw-expert-form__field--full' : '';
+		$field_id     = $field_key;
+		$field_value  = isset( $values[ $field_key ] ) ? $values[ $field_key ] : '';
+		$field_class  = ! empty( $field['full_width'] ) ? ' pgfw-expert-form__field--full' : '';
 		$field_class .= ' ' . sanitize_html_class( $field_key );
 		?>
 		<div class="pgfw-expert-form__field<?php echo esc_attr( $field_class ); ?>">
@@ -252,7 +252,7 @@ class Pdf_Generator_For_Wp_Talk_To_Expert_Form {
 						<span class="pgfw-expert-form__required">*</span>
 					<?php endif; ?>
 				</label>
-			<?php if ( 'textarea' === $field['type'] ) : ?>
+				<?php if ( 'textarea' === $field['type'] ) : ?>
 				<textarea
 					id="<?php echo esc_attr( $field_id ); ?>"
 					name="<?php echo esc_attr( $field_key ); ?>"
@@ -297,8 +297,8 @@ class Pdf_Generator_For_Wp_Talk_To_Expert_Form {
 	private function wps_pgfw_get_talk_to_expert_service_options() {
 		return array(
 			'seo_services'                     => esc_html__( 'SEO services', 'pdf-generator-for-wp' ),
-			'google_ads_setup_and_ga4_setup'  => esc_html__( 'Google Ads Setup and GA4 setup', 'pdf-generator-for-wp' ),
-			'speed_optimization'              => esc_html__( 'Speed Optimization', 'pdf-generator-for-wp' ),
+			'google_ads_setup_and_ga4_setup'   => esc_html__( 'Google Ads Setup and GA4 setup', 'pdf-generator-for-wp' ),
+			'speed_optimization'               => esc_html__( 'Speed Optimization', 'pdf-generator-for-wp' ),
 			'woocommerce_development_services' => esc_html__( 'WooCommerce Development Services', 'pdf-generator-for-wp' ),
 		);
 	}
@@ -310,10 +310,10 @@ class Pdf_Generator_For_Wp_Talk_To_Expert_Form {
 	 */
 	private function wps_pgfw_get_talk_to_expert_budget_options() {
 		return array(
-			''               => 'Please Select',
-			'500-1000'   => '$500 - $1000',
-			'1001-5000'  => '$1001 - $5000',
-			'5001-10000' => '$5001 - $10000',
+			''            => 'Please Select',
+			'500-1000'    => '$500 - $1000',
+			'1001-5000'   => '$1001 - $5000',
+			'5001-10000'  => '$5001 - $10000',
 			'10001-15000' => '$10001 - $15000',
 		);
 	}
@@ -338,13 +338,13 @@ class Pdf_Generator_For_Wp_Talk_To_Expert_Form {
 		}
 
 		return array(
-			'firstname' => $first_name,
-			'lastname'  => $last_name,
-			'email'     => ! empty( $current_user->user_email ) ? $current_user->user_email : '',
-			'phone'     => '',
+			'firstname'                           => $first_name,
+			'lastname'                            => $last_name,
+			'email'                               => ! empty( $current_user->user_email ) ? $current_user->user_email : '',
+			'phone'                               => '',
 			'what_services_do_you_need_help_with' => array(),
-			'budget'    => '',
-			'message'   => '',
+			'budget'                              => '',
+			'message'                             => '',
 		);
 	}
 
@@ -450,24 +450,24 @@ class Pdf_Generator_For_Wp_Talk_To_Expert_Form {
 				}
 			)
 		);
-		$budget = isset( $form_data['budget'] ) ? sanitize_text_field( $form_data['budget'] ) : '';
-		$budget = in_array( $budget, $allowed_budgets, true ) ? $budget : '';
+		$budget            = isset( $form_data['budget'] ) ? sanitize_text_field( $form_data['budget'] ) : '';
+		$budget            = in_array( $budget, $allowed_budgets, true ) ? $budget : '';
 
 		return array(
-			'firstname' => isset( $form_data['firstname'] ) ? sanitize_text_field( $form_data['firstname'] ) : '',
-			'lastname'  => isset( $form_data['lastname'] ) ? sanitize_text_field( $form_data['lastname'] ) : '',
-			'email'     => isset( $form_data['email'] ) ? sanitize_email( $form_data['email'] ) : '',
-			'phone'     => isset( $form_data['phone'] ) ? sanitize_text_field( $form_data['phone'] ) : '',
+			'firstname'                           => isset( $form_data['firstname'] ) ? sanitize_text_field( $form_data['firstname'] ) : '',
+			'lastname'                            => isset( $form_data['lastname'] ) ? sanitize_text_field( $form_data['lastname'] ) : '',
+			'email'                               => isset( $form_data['email'] ) ? sanitize_email( $form_data['email'] ) : '',
+			'phone'                               => isset( $form_data['phone'] ) ? sanitize_text_field( $form_data['phone'] ) : '',
 			'what_services_do_you_need_help_with' => $selected_services,
-			'budget'     => isset( $form_data['budget'] ) ? $budget : '',
-			'message'   => isset( $form_data['message'] ) ? sanitize_textarea_field( $form_data['message'] ) : '',
+			'budget'                              => isset( $form_data['budget'] ) ? $budget : '',
+			'message'                             => isset( $form_data['message'] ) ? sanitize_textarea_field( $form_data['message'] ) : '',
 		);
 	}
 
 	/**
 	 * Prepare a HubSpot field payload.
 	 *
-	 * @param string $field_name HubSpot field name.
+	 * @param string       $field_name HubSpot field name.
 	 * @param string|array $field_value Field value.
 	 * @return array|null
 	 */
@@ -574,7 +574,7 @@ class Pdf_Generator_For_Wp_Talk_To_Expert_Form {
 		$placeholders = implode( ', ', array_fill( 0, count( $paid_statuses ), '%s' ) );
 		$cutoff_date  = gmdate( 'Y-m-d H:i:s', strtotime( '-12 months' ) );
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name and placeholders are generated internally before prepare() binds values.
-		$revenue      = $wpdb->get_var(
+		$revenue = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COALESCE(SUM(total_sales), 0)
 				FROM {$table_name}

--- a/includes/class-pdf-generator-for-wp.php
+++ b/includes/class-pdf-generator-for-wp.php
@@ -347,7 +347,7 @@ class Pdf_Generator_For_Wp {
 	 * @return    Pdf_Generator_For_Wp_Loader    Orchestrates the hooks of the plugin.
 	 */
 	public function pgfw_get_loader() {
-		 return $this->loader;
+		return $this->loader;
 	}
 
 
@@ -394,7 +394,7 @@ class Pdf_Generator_For_Wp {
 			'name'  => 'pdf-generator-for-wp-advanced',
 		);
 
-		$pgfw_default_tabs['pdf-generator-for-wp-meta-fields'] = array(
+		$pgfw_default_tabs['pdf-generator-for-wp-meta-fields']  = array(
 			'title' => esc_html__( 'Meta Fields Settings', 'pdf-generator-for-wp' ),
 			'name'  => 'pdf-generator-for-wp-meta-fields',
 		);
@@ -497,7 +497,7 @@ class Pdf_Generator_For_Wp {
 	 * @return array
 	 */
 	public function wps_pgfw_plug_layout_setting_sub_tabs_dummy() {
-		 $pgfw_default_sub_tabs = array();
+		$pgfw_default_sub_tabs = array();
 		$pgfw_default_sub_tabs = apply_filters( 'pgfw_plugin_standard_admin_settings_sub_tabs_dummy', $pgfw_default_sub_tabs );
 		return $pgfw_default_sub_tabs;
 	}
@@ -508,7 +508,7 @@ class Pdf_Generator_For_Wp {
 	 * @param string $path path file for inclusion.
 	 * @param array  $params parameters to pass to the file for access.
 	 */
-	public function wps_pgfw_plug_load_template( $path, $params = array() ) {
+	public function wps_pgfw_plug_load_template( $path, $params = array() ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- $params is exposed to the included template's scope for its own use.
 		$pgfw_file_path = PDF_GENERATOR_FOR_WP_DIR_PATH . $path;
 		$pgfw_file_path = apply_filters( 'wps_pgfw_setting_page_loading_filter_hook', $pgfw_file_path, $path );
 		if ( file_exists( $pgfw_file_path ) ) {
@@ -526,7 +526,7 @@ class Pdf_Generator_For_Wp {
 	 * @param string $path path file for inclusion.
 	 * @param array  $params parameters to pass to the file for access.
 	 */
-	public function wps_pgfw_plug_load_sub_template( $path, $params = array() ) {
+	public function wps_pgfw_plug_load_sub_template( $path, $params = array() ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- $params is exposed to the included template's scope for its own use.
 		$pgfw_file_path = PDF_GENERATOR_FOR_WP_DIR_PATH . $path;
 		$pgfw_file_path = apply_filters( 'wps_pgfw_setting_sub_page_loading_filter_hook', $pgfw_file_path, $path );
 		if ( file_exists( $pgfw_file_path ) ) {

--- a/includes/pdf-generator-for-wp-global-functions.php
+++ b/includes/pdf-generator-for-wp-global-functions.php
@@ -152,7 +152,7 @@ function wps_pgfw_host_is_public( $host ) {
 	}
 
 	// Strip IPv6 brackets if present.
-	$host = trim( $host, "[]" );
+	$host = trim( $host, '[]' );
 
 	$ips = array();
 	if ( filter_var( $host, FILTER_VALIDATE_IP ) ) {
@@ -331,7 +331,7 @@ function wps_pgfw_upload_pdf() {
 		'test_form' => false,
 		'mimes'     => array( 'pdf' => 'application/pdf' ),
 	);
-	$file_arr = array(
+	$file_arr  = array(
 		'name'     => $file['name'],
 		'type'     => $file['type'],
 		'tmp_name' => $file['tmp_name'],
@@ -350,7 +350,7 @@ function wps_pgfw_upload_pdf() {
 		'post_content'   => '',
 		'post_status'    => 'inherit',
 	);
-	$attach_id = wp_insert_attachment( $attachment, $movefile['file'] );
+	$attach_id  = wp_insert_attachment( $attachment, $movefile['file'] );
 	if ( is_wp_error( $attach_id ) ) {
 		wp_send_json_error( $attach_id->get_error_message() );
 	}
@@ -369,10 +369,10 @@ function wps_pgfw_upload_pdf() {
 /**
  * Get option with caching support.
  *
- * @param string $option  Option name.
- * @param mixed  $default Default value if option doesn't exist.
+ * @param string $option        Option name.
+ * @param mixed  $default_value Default value if option doesn't exist.
  * @return mixed Option value or default.
  */
-function wps_pgfw_get_option_cached( $option, $default = '' ) {
-	return get_option( $option, $default );
+function wps_pgfw_get_option_cached( $option, $default_value = '' ) {
+	return get_option( $option, $default_value );
 }

--- a/onboarding/templates/pdf-generator-for-wp-deactivation-template.php
+++ b/onboarding/templates/pdf-generator-for-wp-deactivation-template.php
@@ -12,7 +12,7 @@
  */
 
 global $pagenow, $pgfw_wps_pgfw_obj;
-if ( empty( $pagenow ) || 'plugins.php' != $pagenow ) {
+if ( empty( $pagenow ) || 'plugins.php' !== $pagenow ) {
 	return false;
 }
 

--- a/package/rest-api/class-pdf-generator-for-wp-rest-api.php
+++ b/package/rest-api/class-pdf-generator-for-wp-rest-api.php
@@ -57,7 +57,6 @@ class Pdf_Generator_For_Wp_Rest_Api {
 
 		$this->plugin_name = $plugin_name;
 		$this->version     = $version;
-
 	}
 
 
@@ -104,7 +103,7 @@ class Pdf_Generator_For_Wp_Rest_Api {
 	 * @param WP_REST_Request $request Request data.
 	 * @return bool|
 	 */
-	public function wps_pgfw_tab_permission_check( $request ) {
+	public function wps_pgfw_tab_permission_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- $request is required by the REST permission_callback signature.
 		return current_user_can( 'manage_options' );
 	}
 
@@ -145,11 +144,13 @@ class Pdf_Generator_For_Wp_Rest_Api {
 			? $pgfw_wps_pgfw_obj->wps_pgfw_get_dashboard_header_content( $tab )
 			: array();
 
-		return rest_ensure_response( array(
-			'tab'    => $tab,
-			'html'   => $html,
-			'header' => $header,
-		) );
+		return rest_ensure_response(
+			array(
+				'tab'    => $tab,
+				'html'   => $html,
+				'header' => $header,
+			)
+		);
 	}
 
 
@@ -160,7 +161,7 @@ class Pdf_Generator_For_Wp_Rest_Api {
 	 * @return  Array   $result   return rest response to server from where the endpoint hits.
 	 * @since    1.0.0
 	 */
-	public function wps_pgfw_default_permission_check( $request ) {
+	public function wps_pgfw_default_permission_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- $request is required by the REST permission_callback signature.
 
 		// Add rest api validation for each request.
 		$result = true;
@@ -180,7 +181,7 @@ class Pdf_Generator_For_Wp_Rest_Api {
 		require_once PDF_GENERATOR_FOR_WP_DIR_PATH . 'package/rest-api/version1/class-pdf-generator-for-wp-api-process.php';
 		$wps_pgfw_api_obj     = new Pdf_Generator_For_Wp_Api_Process();
 		$wps_pgfw_resultsdata = $wps_pgfw_api_obj->wps_pgfw_default_process( $request );
-		if ( is_array( $wps_pgfw_resultsdata ) && isset( $wps_pgfw_resultsdata['status'] ) && 200 == $wps_pgfw_resultsdata['status'] ) {
+		if ( is_array( $wps_pgfw_resultsdata ) && isset( $wps_pgfw_resultsdata['status'] ) && 200 === $wps_pgfw_resultsdata['status'] ) {
 			unset( $wps_pgfw_resultsdata['status'] );
 			$wps_pgfw_response = new WP_REST_Response( $wps_pgfw_resultsdata, 200 );
 		} else {

--- a/package/rest-api/version1/class-pdf-generator-for-wp-api-process.php
+++ b/package/rest-api/version1/class-pdf-generator-for-wp-api-process.php
@@ -32,7 +32,6 @@ if ( ! class_exists( 'Pdf_Generator_For_Wp_Api_Process' ) ) {
 		 * @since    1.0.0
 		 */
 		public function __construct() {
-
 		}
 
 		/**
@@ -48,7 +47,7 @@ if ( ! class_exists( 'Pdf_Generator_For_Wp_Api_Process' ) ) {
 			// Write your custom code here.
 
 			$wps_pgfw_rest_response['status'] = 200;
-			$wps_pgfw_rest_response['data'] = $pgfw_request->get_headers();
+			$wps_pgfw_rest_response['data']   = $pgfw_request->get_headers();
 			return $wps_pgfw_rest_response;
 		}
 	}

--- a/pdf-generator-for-wp.php
+++ b/pdf-generator-for-wp.php
@@ -49,7 +49,7 @@ add_action(
 );
 require_once ABSPATH . '/wp-admin/includes/plugin.php';
 $pgfw_old_plugin_exists = false;
-$plug           = get_plugins();
+$plug                   = get_plugins();
 if ( isset( $plug['wordpress-pdf-generator/wordpress-pdf-generator.php'] ) ) {
 	if ( version_compare( $plug['wordpress-pdf-generator/wordpress-pdf-generator.php']['Version'], '3.0.5', '<' ) ) {
 		$pgfw_old_plugin_exists = true;
@@ -98,7 +98,7 @@ function activate_pdf_generator_for_wp( $network_wide ) {
 	$wps_pgfw_active_plugin = get_option( 'wps_all_plugins_active', array() );
 	if ( ! is_array( $wps_pgfw_active_plugin ) ) {
 		// If someone stored JSON in the past, try to decode it.
-		$decoded = is_string( $wps_pgfw_active_plugin ) ? json_decode( $wps_pgfw_active_plugin, true ) : null;
+		$decoded                = is_string( $wps_pgfw_active_plugin ) ? json_decode( $wps_pgfw_active_plugin, true ) : null;
 		$wps_pgfw_active_plugin = is_array( $decoded ) ? $decoded : array();
 	}
 
@@ -207,28 +207,28 @@ function wps_register_new_widgets( $widgets_manager ) {
 		'wps_pdf_embed',
 	);
 
-	$always_include = array( 'wps_pdf_shortcode', 'wps_single_image' );
-	$pro_only_widgets = array( 'wps_ai_chatbot', 'wps_pdf_embed', 'wps_rss_feed' );
+	$always_include    = array( 'wps_pdf_shortcode', 'wps_single_image' );
+	$pro_only_widgets  = array( 'wps_ai_chatbot', 'wps_pdf_embed', 'wps_rss_feed' );
 	$tofw_only_widgets = array( 'wps_tracking_info' );
 
 	// Check if Pro plugin is active.
 	include_once ABSPATH . 'wp-admin/includes/plugin.php';
-	$pdf_is_pro_plugin_active = is_plugin_active( 'wordpress-pdf-generator/wordpress-pdf-generator.php' );
+	$pdf_is_pro_plugin_active  = is_plugin_active( 'wordpress-pdf-generator/wordpress-pdf-generator.php' );
 	$tofw_is_pro_plugin_active = is_plugin_active( 'track-orders-for-woocommerce/track-orders-for-woocommerce.php' );
 
 	foreach ( $wps_pgfw_sources as $source ) {
 		$should_load = false;
 
-		if ( in_array( $source, $always_include ) ) {
+		if ( in_array( $source, $always_include, true ) ) {
 			$should_load = true;
-		} elseif ( in_array( $source, $pro_only_widgets ) ) {
+		} elseif ( in_array( $source, $pro_only_widgets, true ) ) {
 			$option_key = str_replace( 'wps_', '', $source );
 			$option_key = "wps_embed_source_{$option_key}";
 
 			if ( 'on' === get_option( $option_key, '' ) && $pdf_is_pro_plugin_active ) {
 				$should_load = true;
 			}
-		} elseif ( in_array( $source, $tofw_only_widgets ) ) {
+		} elseif ( in_array( $source, $tofw_only_widgets, true ) ) {
 			$option_key = str_replace( 'wps_', '', $source );
 			$option_key = "wps_embed_source_{$option_key}";
 
@@ -247,9 +247,9 @@ function wps_register_new_widgets( $widgets_manager ) {
 			continue;
 		}
 
-		$wps_source = str_replace( '_', '-', $source );
+		$wps_source        = str_replace( '_', '-', $source );
 		$wps_sources_class = strtoupper( strtok( $source, '_' ) ) . '_' . ucfirst( substr( $source, strpos( $source, '_' ) + 1 ) );
-		$wps_widget_file = plugin_dir_path( __FILE__ ) . "Elementor/class-elementor-widget-{$wps_source}.php";
+		$wps_widget_file   = plugin_dir_path( __FILE__ ) . "Elementor/class-elementor-widget-{$wps_source}.php";
 
 		if ( file_exists( $wps_widget_file ) ) {
 			require_once $wps_widget_file;
@@ -373,7 +373,7 @@ add_action( 'after_plugin_row_wordpress-pdf-generator/wordpress-pdf-generator.ph
  * @param array  $plugin_data An array of plugin data.
  * @param string $status Status filter currently applied to the plugin list.
  */
-function wps_wpg_old_upgrade_notice( $plugin_file, $plugin_data, $status ) {
+function wps_wpg_old_upgrade_notice( $plugin_file, $plugin_data, $status ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- required by the after_plugin_row_{$plugin_file} hook signature.
 
 	global $pgfw_old_plugin_exists;
 	if ( $pgfw_old_plugin_exists ) {
@@ -439,10 +439,10 @@ add_action( 'after_plugin_row_' . plugin_basename( __FILE__ ), 'wps_wpg_pro_pdf_
  * @param array  $plugin_data An array of plugin data.
  * @param string $status Status filter currently applied to the plugin list.
  */
-function wps_wpg_pro_pdf_upgrade_notice( $plugin_file, $plugin_data, $status ) {
+function wps_wpg_pro_pdf_upgrade_notice( $plugin_file, $plugin_data, $status ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- required by the after_plugin_row_{$plugin_file} hook signature.
 	$plugin_admin = new Pdf_Generator_For_Wp_Admin( 'pdf-generator-for-wp', '1.0.7' );
 	$count        = $plugin_admin->wps_wpg_get_count( 'settings' );
-	$key3 = get_option( 'wps_wpg_activated_timestamp' );
+	$key3         = get_option( 'wps_wpg_activated_timestamp' );
 	if ( ! empty( $count ) && ( empty( $key3 ) ) ) {
 		?>
 
@@ -535,7 +535,7 @@ function wps_pgfw_tracking_info_shortcode( $atts ) {
 	}
 
 	$wps_pgfw_order_id = intval( $atts['order_id'] );
-	$wps_pgfw_order = wc_get_order( $wps_pgfw_order_id );
+	$wps_pgfw_order    = wc_get_order( $wps_pgfw_order_id );
 
 	if ( ! $wps_pgfw_order ) {
 		return '<div style="color:red;">Invalid Order ID.</div>';
@@ -546,7 +546,7 @@ function wps_pgfw_tracking_info_shortcode( $atts ) {
 	$wps_pgfw_estimated_time  = $wps_pgfw_order->get_meta( 'wps_tofw_estimated_delivery_time' );
 	$wps_pgfw_carrier_base    = $wps_pgfw_order->get_meta( 'wps_tofwp_enhanced_order_company' );
 	$wps_pgfw_tracking_number = $wps_pgfw_order->get_meta( 'wps_tofwp_enhanced_tracking_no' );
-	$wps_pgfw_tracking_link   = $wps_pgfw_carrier_base && $wps_pgfw_tracking_number ? esc_url( $wps_pgfw_carrier_base . urlencode( $wps_pgfw_tracking_number ) ) : '';
+	$wps_pgfw_tracking_link   = $wps_pgfw_carrier_base && $wps_pgfw_tracking_number ? esc_url( $wps_pgfw_carrier_base . rawurlencode( $wps_pgfw_tracking_number ) ) : '';
 
 	$wps_pgfw_saved_settings  = get_option( 'wps_tofwp_general_settings_saved' );
 	$wps_pgfw_saved_providers = isset( $wps_pgfw_saved_settings['providers_data'] ) ? $wps_pgfw_saved_settings['providers_data'] : array();
@@ -556,7 +556,7 @@ function wps_pgfw_tracking_info_shortcode( $atts ) {
 
 	// Text alignment logic.
 	$wps_pgfw_allowed_alignments = array( 'left', 'center', 'right' );
-	$wps_pgfw_align = in_array( strtolower( $atts['align'] ), $wps_pgfw_allowed_alignments ) ? strtolower( $atts['align'] ) : 'center';
+	$wps_pgfw_align              = in_array( strtolower( $atts['align'] ), $wps_pgfw_allowed_alignments, true ) ? strtolower( $atts['align'] ) : 'center';
 
 	$wps_pgfw_container_style = 'max-width: 500px; padding: 20px; border-radius: 12px; background: #f8f9fa; box-shadow: 0 4px 12px rgba(0,0,0,0.1); font-family: Arial, sans-serif;';
 	if ( 'center' === $wps_pgfw_align ) {
@@ -569,18 +569,18 @@ function wps_pgfw_tracking_info_shortcode( $atts ) {
 
 	ob_start();
 	if ( is_plugin_active( 'track-orders-for-woocommerce-pro/track-orders-for-woocommerce-pro.php' ) ) {
-		$wps_pgfw_plugin_url = TRACK_ORDERS_FOR_WOOCOMMERCE_PRO_DIR_URL;
-		$wps_pgfw_icon_path  = $wps_pgfw_plugin_url . 'admin/partials/assets/icons/';
+		$wps_pgfw_plugin_url           = TRACK_ORDERS_FOR_WOOCOMMERCE_PRO_DIR_URL;
+		$wps_pgfw_icon_path            = $wps_pgfw_plugin_url . 'admin/partials/assets/icons/';
 		$wps_pgfw_matched_carrier_name = '';
-		$wps_pgfw_icon_url = '';
+		$wps_pgfw_icon_url             = '';
 
 		// Detect matched carrier and icon.
 		foreach ( $wps_pgfw_saved_providers as $wps_pgfw_name => $wps_pgfw_url ) {
 			if ( strpos( $wps_pgfw_carrier_base, $wps_pgfw_url ) !== false ) {
 				$wps_pgfw_matched_carrier_name = $wps_pgfw_name;
-				$wps_pgfw_icon_file = strtolower( str_replace( ' ', '', $wps_pgfw_matched_carrier_name ) ) . '.png';
-				$wps_pgfw_icon_full_path = TRACK_ORDERS_FOR_WOOCOMMERCE_PRO_DIR_PATH . 'admin/partials/assets/icons/' . $wps_pgfw_icon_file;
-				$wps_pgfw_icon_url = file_exists( $wps_pgfw_icon_full_path ) ? $wps_pgfw_icon_path . $wps_pgfw_icon_file : $wps_pgfw_icon_path . 'default.png';
+				$wps_pgfw_icon_file            = strtolower( str_replace( ' ', '', $wps_pgfw_matched_carrier_name ) ) . '.png';
+				$wps_pgfw_icon_full_path       = TRACK_ORDERS_FOR_WOOCOMMERCE_PRO_DIR_PATH . 'admin/partials/assets/icons/' . $wps_pgfw_icon_file;
+				$wps_pgfw_icon_url             = file_exists( $wps_pgfw_icon_full_path ) ? $wps_pgfw_icon_path . $wps_pgfw_icon_file : $wps_pgfw_icon_path . 'default.png';
 				break;
 			}
 		}
@@ -672,7 +672,7 @@ function wps_twitch_stream_with_chat_shortcode( $atts ) {
 	}
 
 	// Set the parent domain (required by Twitch embed policy).
-	$host = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
+	$host   = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
 	$parent = esc_attr( $host );
 
 	// Start building output.
@@ -722,9 +722,9 @@ function wps_strava_embed_shortcode( $atts ) {
 	// Merge user-provided attributes with defaults.
 	$atts = shortcode_atts(
 		array(
-			'id' => '', // Strava Activity or Segment ID.
-			'type' => 'activity', // Type of embed (activity, segment, etc.).
-			'style' => 'standard', // Visual style of embed.
+			'id'         => '', // Strava Activity or Segment ID.
+			'type'       => 'activity', // Type of embed (activity, segment, etc.).
+			'style'      => 'standard', // Visual style of embed.
 			'from_embed' => 'false', // Optional flag for embed behavior.
 		),
 		$atts,
@@ -774,8 +774,8 @@ function wps_chatbot_ai_shortcode( $atts ) {
 	// Set default values and merge with user-supplied attributes.
 	$atts = shortcode_atts(
 		array(
-			'url' => '',
-			'height' => '700px',
+			'url'          => '',
+			'height'       => '700px',
 			'header_color' => '#4e54c8',
 			'header_title' => 'AI Chat Assistant',
 		),
@@ -885,11 +885,11 @@ function wps_rssapp_feed_shortcode( $atts ) {
 	// Define default attribute values and merge with user-supplied attributes.
 	$atts = shortcode_atts(
 		array(
-			'url' => '',
-			'height' => '600px',
-			'title' => '📰 Latest News',
-			'bg_color' => '#ffffff',
-			'text_color' => '#333333',
+			'url'          => '',
+			'height'       => '600px',
+			'title'        => '📰 Latest News',
+			'bg_color'     => '#ffffff',
+			'text_color'   => '#333333',
 			'border_color' => '#eeeeee',
 		),
 		$atts
@@ -953,9 +953,9 @@ function wps_display_uploaded_image_shortcode( $atts ) {
 	// Set default attributes for the shortcode.
 	$atts = shortcode_atts(
 		array(
-			'id'  => '',    // Attachment ID.
-			'url' => '',    // Image URL if no ID is given.
-			'alt' => 'Image', // Alt text for accessibility.
+			'id'     => '',    // Attachment ID.
+			'url'    => '',    // Image URL if no ID is given.
+			'alt'    => 'Image', // Alt text for accessibility.
 			'width'  => '100%', // Width of the image.
 			'height' => 'auto',  // Height of the image.
 		),
@@ -1005,9 +1005,9 @@ if ( ! function_exists( 'wps_banner_notification_plugin_html' ) ) {
 		if ( 'wc-settings' === $page_param || in_array( $screen->id, $target_screens, true ) ) {
 			$banner_id = get_option( 'wps_wgm_notify_new_banner_id', false );
 			if ( isset( $banner_id ) && '' !== $banner_id ) {
-				$hidden_banner_id            = get_option( 'wps_wgm_notify_hide_baneer_notification', false );
-				$banner_image = get_option( 'wps_wgm_notify_new_banner_image', '' );
-				$banner_url = get_option( 'wps_wgm_notify_new_banner_url', '' );
+				$hidden_banner_id = get_option( 'wps_wgm_notify_hide_baneer_notification', false );
+				$banner_image     = get_option( 'wps_wgm_notify_new_banner_image', '' );
+				$banner_url       = get_option( 'wps_wgm_notify_new_banner_url', '' );
 				if ( isset( $hidden_banner_id ) && $hidden_banner_id < $banner_id ) {
 
 					if ( '' !== $banner_image && '' !== $banner_url ) {
@@ -1036,23 +1036,23 @@ add_action( 'init', 'wps_pgfw_register_flipbook_taxonomy' );
  */
 function wps_register_flipbook_post_type() {
 	$general_settings_data = get_option( 'pgfw_general_settings_save', array() );
-	$pgfw_flipbook_enable = array_key_exists( 'pgfw_flipbook_enable', $general_settings_data ) ? $general_settings_data['pgfw_flipbook_enable'] : '';
+	$pgfw_flipbook_enable  = array_key_exists( 'pgfw_flipbook_enable', $general_settings_data ) ? $general_settings_data['pgfw_flipbook_enable'] : '';
 
 	$args = array(
-		'labels'             => array(
-			'name'               => __( 'Flipbooks', 'wps-flipbook' ),
-			'singular_name'      => __( 'Flipbook', 'wps-flipbook' ),
-			'menu_name'          => __( 'Flipbooks', 'wps-flipbook' ),
+		'labels'          => array(
+			'name'          => __( 'Flipbooks', 'wps-flipbook' ),
+			'singular_name' => __( 'Flipbook', 'wps-flipbook' ),
+			'menu_name'     => __( 'Flipbooks', 'wps-flipbook' ),
 		),
-		'public'             => false,
-		'show_ui'            => ( 'yes' === $pgfw_flipbook_enable ),
-		'show_in_menu'       => ( 'yes' === $pgfw_flipbook_enable ),
-		'menu_icon'          => 'dashicons-book-alt',
-		'supports'           => array( 'title' ),
-		'capability_type'    => 'post',
-		'has_archive'        => false,
-		'rewrite'            => false,
-		'query_var'          => true,
+		'public'          => false,
+		'show_ui'         => ( 'yes' === $pgfw_flipbook_enable ),
+		'show_in_menu'    => ( 'yes' === $pgfw_flipbook_enable ),
+		'menu_icon'       => 'dashicons-book-alt',
+		'supports'        => array( 'title' ),
+		'capability_type' => 'post',
+		'has_archive'     => false,
+		'rewrite'         => false,
+		'query_var'       => true,
 	);
 
 	register_post_type( 'flipbook', $args );
@@ -1063,18 +1063,18 @@ function wps_register_flipbook_post_type() {
  */
 function wps_pgfw_register_flipbook_taxonomy() {
 	$general_settings_data = get_option( 'pgfw_general_settings_save', array() );
-	$pgfw_flipbook_enable = array_key_exists( 'pgfw_flipbook_enable', $general_settings_data ) ? $general_settings_data['pgfw_flipbook_enable'] : '';
+	$pgfw_flipbook_enable  = array_key_exists( 'pgfw_flipbook_enable', $general_settings_data ) ? $general_settings_data['pgfw_flipbook_enable'] : '';
 
 	if ( 'yes' === $pgfw_flipbook_enable ) {
 		register_taxonomy(
 			'flipbook_category',
 			'flipbook',
 			array(
-				'label' => 'Flipbook Categories',
-				'hierarchical' => true,
-				'show_ui' => true,
+				'label'             => 'Flipbook Categories',
+				'hierarchical'      => true,
+				'show_ui'           => true,
 				'show_admin_column' => true,
-				'rewrite' => array( 'slug' => 'flipbook-category' ),
+				'rewrite'           => array( 'slug' => 'flipbook-category' ),
 			)
 		);
 	}
@@ -1121,9 +1121,9 @@ function wps_pgfw_notification_plugin_html() {
 	if ( ( isset( $_GET['page'] ) && 'pdf_generator_for_wp_menu' === $_GET['page'] ) ) {
 		$banner_id = get_option( 'wps_wgm_notify_new_banner_id', false );
 		if ( isset( $banner_id ) && '' !== $banner_id ) {
-			$hidden_banner_id            = get_option( 'wps_wgm_notify_hide_baneer_notification', false );
-			$banner_image = get_option( 'wps_wgm_notify_new_banner_image', '' );
-			$banner_url = get_option( 'wps_wgm_notify_new_banner_url', '' );
+			$hidden_banner_id = get_option( 'wps_wgm_notify_hide_baneer_notification', false );
+			$banner_image     = get_option( 'wps_wgm_notify_new_banner_image', '' );
+			$banner_url       = get_option( 'wps_wgm_notify_new_banner_url', '' );
 			if ( isset( $hidden_banner_id ) && $hidden_banner_id < $banner_id ) {
 
 				if ( '' !== $banner_image && '' !== $banner_url ) {

--- a/public/class-pdf-generator-for-wp-public.php
+++ b/public/class-pdf-generator-for-wp-public.php
@@ -149,36 +149,36 @@ class Pdf_Generator_For_Wp_Public {
 		$guest_access_pdf             = array_key_exists( 'pgfw_guest_access', $display_setings_arr ) ? $display_setings_arr['pgfw_guest_access'] : '';
 		$pgfw_guest_download_or_email = array_key_exists( 'pgfw_guest_download_or_email', $display_setings_arr ) ? $display_setings_arr['pgfw_guest_download_or_email'] : '';
 		$pgfw_user_download_or_email  = array_key_exists( 'pgfw_user_download_or_email', $display_setings_arr ) ? $display_setings_arr['pgfw_user_download_or_email'] : '';
-		$allowedposttags = array(
-			'div' => array(
+		$allowedposttags              = array(
+			'div'    => array(
 
 				'title' => array(),
 				'class' => array(),
-				'id' => true,
-				'style'            => true,
+				'id'    => true,
+				'style' => true,
 			),
-			'a' => array(
-				'href' => true,
+			'a'      => array(
+				'href'  => true,
 				'title' => true,
-				'img' => true,
+				'img'   => true,
 				'class' => true,
 				'style' => array(),
 			),
-			'img' => array(
-				'src' => array(),
+			'img'    => array(
+				'src'   => array(),
 				'class' => array(),
-				'alt' => array(),
+				'alt'   => array(),
 				'title' => array(),
 				'style' => array(),
 			),
-			'input'    => array(
-				'type'  => true,
-				'class' => true,
-				'name'  => true,
-				'value' => true,
-				'id'    => true,
-				'style' => true,
-				'checked'   => array(),
+			'input'  => array(
+				'type'    => true,
+				'class'   => true,
+				'name'    => true,
+				'value'   => true,
+				'id'      => true,
+				'style'   => true,
+				'checked' => array(),
 			),
 			'button' => array(
 				'id' => true,
@@ -266,9 +266,9 @@ class Pdf_Generator_For_Wp_Public {
 		// Set default attributes for the shortcode.
 		$atts = shortcode_atts(
 			array(
-				'id'  => $atts['id'],    // Attachment ID.
-				'url' => '',    // Image URL if no ID is given.
-				'alt' => 'Image', // Alt text for accessibility.
+				'id'     => $atts['id'],    // Attachment ID.
+				'url'    => '',    // Image URL if no ID is given.
+				'alt'    => 'Image', // Alt text for accessibility.
 				'width'  => isset( $atts['width'] ) ? $atts['width'] : 10, // Width of the image.
 				'height' => isset( $atts['height'] ) ? $atts['height'] : 10,  // Height of the image.
 			),
@@ -394,9 +394,9 @@ class Pdf_Generator_For_Wp_Public {
 	 * @return void
 	 */
 	public function wps_pgfw_flipbook_shortcode_callback() {
-		$general_settings_data     = get_option( 'pgfw_general_settings_save', array() );
-		$pgfw_enable_plugin        = array_key_exists( 'pgfw_enable_plugin', $general_settings_data ) ? $general_settings_data['pgfw_enable_plugin'] : '';
-		$pgfw_flipbook_enable = array_key_exists( 'pgfw_flipbook_enable', $general_settings_data ) ? $general_settings_data['pgfw_flipbook_enable'] : '';
+		$general_settings_data = get_option( 'pgfw_general_settings_save', array() );
+		$pgfw_enable_plugin    = array_key_exists( 'pgfw_enable_plugin', $general_settings_data ) ? $general_settings_data['pgfw_enable_plugin'] : '';
+		$pgfw_flipbook_enable  = array_key_exists( 'pgfw_flipbook_enable', $general_settings_data ) ? $general_settings_data['pgfw_flipbook_enable'] : '';
 		if ( 'yes' !== $pgfw_enable_plugin || 'yes' !== $pgfw_flipbook_enable ) {
 			return;
 		}
@@ -411,14 +411,14 @@ class Pdf_Generator_For_Wp_Public {
 	 * @return string HTML output for the flipbook.
 	 */
 	public function wps_pgfw_flipbook_shortcode_html( $atts ) {
-		$atts = shortcode_atts( array( 'id' => 0 ), $atts );
+		$atts    = shortcode_atts( array( 'id' => 0 ), $atts );
 		$post_id = (int) $atts['id'];
 
 		if ( ! $post_id ) {
 			return '<p>No flipbook ID provided.</p>';
 		}
 
-		$post     = get_post( $post_id );
+		$post = get_post( $post_id );
 		if ( ! $post || 'flipbook' !== $post->post_type || 'publish' !== get_post_status( $post->ID ) ) {
 			return '<p>Invalid flipbook ID.</p>';
 		}
@@ -426,30 +426,30 @@ class Pdf_Generator_For_Wp_Public {
 		$width  = get_post_meta( $post_id, '_fb_width', true ) ? get_post_meta( $post_id, '_fb_width', true ) : 400;
 		$height = get_post_meta( $post_id, '_fb_height', true ) ? get_post_meta( $post_id, '_fb_height', true ) : 300;
 
-		$pdf_html = get_post_meta( $post_id, '_fb_pdf_html', true );
-		$cover_image = get_post_meta( $post_id, '_fb_cover_image', true );
-		$back_image  = get_post_meta( $post_id, '_fb_back_image', true );
-		$wps_tool_btn = get_post_meta( $post->ID, '_fb_tool_btn', true );
+		$pdf_html           = get_post_meta( $post_id, '_fb_pdf_html', true );
+		$cover_image        = get_post_meta( $post_id, '_fb_cover_image', true );
+		$back_image         = get_post_meta( $post_id, '_fb_back_image', true );
+		$wps_tool_btn       = get_post_meta( $post->ID, '_fb_tool_btn', true );
 		$wps_add_cover_page = get_post_meta( $post->ID, '_fb_show_cover', true );
-		$flip_sound_url = get_post_meta( $post->ID, '_fb_flip_sound_url', true );
-		$flip_sound_volume = get_post_meta( $post->ID, '_fb_flip_sound_volume', true );
+		$flip_sound_url     = get_post_meta( $post->ID, '_fb_flip_sound_url', true );
+		$flip_sound_volume  = get_post_meta( $post->ID, '_fb_flip_sound_volume', true );
 
 		$mobile_scroll_support = get_post_meta( $post->ID, '_fb_mobileScrollSupport', true );
 		$max_shadow_opacity    = get_post_meta( $post->ID, '_fb_maxShadowOpacity', true );
-		$flipping_time        = get_post_meta( $post->ID, '_fb_flippingTime', true );
-		$start_page           = get_post_meta( $post->ID, '_fb_startPage', true );
-		$swipe_distance       = get_post_meta( $post->ID, '_fb_swipeDistance', true );
+		$flipping_time         = get_post_meta( $post->ID, '_fb_flippingTime', true );
+		$start_page            = get_post_meta( $post->ID, '_fb_startPage', true );
+		$swipe_distance        = get_post_meta( $post->ID, '_fb_swipeDistance', true );
 		$use_mouse_events      = get_post_meta( $post->ID, '_fb_useMouseEvents', true );
-		$size                = get_post_meta( $post->ID, '_fb_size', true );
-		$popup_enabled       = get_post_meta( $post->ID, '_fb_popup_enabled', true );
-		$image_urls_json     = get_post_meta( $post->ID, '_fb_image_urls', true );
+		$size                  = get_post_meta( $post->ID, '_fb_size', true );
+		$popup_enabled         = get_post_meta( $post->ID, '_fb_popup_enabled', true );
+		$image_urls_json       = get_post_meta( $post->ID, '_fb_image_urls', true );
 
-		$image_urls = array();
+		$image_urls  = array();
 		$from_images = false;
 		if ( $image_urls_json ) {
 			$decoded = json_decode( $image_urls_json, true );
 			if ( is_array( $decoded ) && count( $decoded ) > 0 ) {
-				$image_urls = array_values( array_map( 'esc_url', $decoded ) );
+				$image_urls  = array_values( array_map( 'esc_url', $decoded ) );
 				$from_images = true;
 			}
 		}
@@ -467,7 +467,7 @@ class Pdf_Generator_For_Wp_Public {
 				$image_urls[] = $back_image;
 			}
 		}
-		$uid = 'flipbook_' . wp_unique_id();
+		$uid             = 'flipbook_' . wp_unique_id();
 		$wps_total_pages = count( $image_urls );
 		ob_start();
 		if ( 1 === (int) $popup_enabled ) {

--- a/public/templates/pdf-generator-for-wp-public-email-storage-modal-template.php
+++ b/public/templates/pdf-generator-for-wp-public-email-storage-modal-template.php
@@ -29,16 +29,16 @@ function pgfw_modal_for_email_template( $url_here, $id ) {
 	$pgfw_pdf_icon_width               = array_key_exists( 'pgfw_pdf_icon_width', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_pdf_icon_width'] : '';
 	$pgfw_pdf_icon_height              = array_key_exists( 'pgfw_pdf_icon_height', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_pdf_icon_height'] : '';
 	if ( is_plugin_active( 'wordpress-pdf-generator/wordpress-pdf-generator.php' ) ) {
-		$wps_wpg_single_pdf_icon_name    = array_key_exists( 'wps_wpg_single_pdf_icon_name', $pgfw_display_settings ) ? $pgfw_display_settings['wps_wpg_single_pdf_icon_name'] : '';
-		$is_pro_active = true;
+		$wps_wpg_single_pdf_icon_name = array_key_exists( 'wps_wpg_single_pdf_icon_name', $pgfw_display_settings ) ? $pgfw_display_settings['wps_wpg_single_pdf_icon_name'] : '';
+		$is_pro_active                = true;
 	} else {
 		$wps_wpg_single_pdf_icon_name = '';
-		$is_pro_active = false;
+		$is_pro_active                = false;
 	}
 
-	$html  = '<div class="pdf-icon-for-the-email" style=" gap:10px;justify-content:' . esc_html( $pgfw_pdf_icon_alignment ) . '">
+	$html = '<div class="pdf-icon-for-the-email" style=" gap:10px;justify-content:' . esc_html( $pgfw_pdf_icon_alignment ) . '">
 				<a href="#" title="' . esc_html__( 'Please Enter Your Email ID', 'pdf-generator-for-wp' ) . '" class="pgfw-single-pdf-download-a"><img src="' . esc_url( $pgfw_single_pdf_download_icon_src ) . '" title="' . esc_html__( 'Generate PDF', 'pdf-generator-for-wp' ) . '" style="height:' . esc_html( $pgfw_pdf_icon_height ) . 'px;">' . $wps_wpg_single_pdf_icon_name . '</a>';
-	$html  = apply_filters( 'wps_pgfw_bulk_download_button_filter_hook', $html, $id );
+	$html = apply_filters( 'wps_pgfw_bulk_download_button_filter_hook', $html, $id );
 
 	if ( is_user_logged_in() ) {
 		$html .= '</div>
@@ -70,7 +70,7 @@ function pgfw_modal_for_email_template( $url_here, $id ) {
 				   </div>
 			   </div>';
 	} else {
-		$html .= '</div>
+		$html     .= '</div>
 		<div id="single-pdf-download">
 			<div class="wps-pdf_email--shadow"></div>
 			<div class="wps-pdf_email-content">

--- a/public/templates/pdf-generator-for-wp-public-pdf-generate-button-template.php
+++ b/public/templates/pdf-generator-for-wp-public-pdf-generate-button-template.php
@@ -23,43 +23,43 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function pgfw_pdf_download_button( $url_here, $id ) {
 
-	$general_settings_data             = get_option( 'pgfw_general_settings_save', array() );
-	$pgfw_pdf_generate_mode            = array_key_exists( 'pgfw_general_pdf_generate_mode', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_generate_mode'] : '';
-	$mode                              = ( 'open_window' === $pgfw_pdf_generate_mode ) ? 'target=_blank' : '';
-	$pgfw_display_settings             = get_option( 'pgfw_save_admin_display_settings', array() );
-	$pgfw_pdf_icon_alignment           = array_key_exists( 'pgfw_display_pdf_icon_alignment', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_display_pdf_icon_alignment'] : '';
-	$sub_pgfw_pdf_single_download_icon = array_key_exists( 'sub_pgfw_pdf_single_download_icon', $pgfw_display_settings ) ? $pgfw_display_settings['sub_pgfw_pdf_single_download_icon'] : '';
-	$pgfw_single_pdf_download_icon_src = ( '' !== $sub_pgfw_pdf_single_download_icon ) ? $sub_pgfw_pdf_single_download_icon : PDF_GENERATOR_FOR_WP_DIR_URL . 'admin/src/images/PDF_Tray.svg';
-	$pgfw_pdf_icon_width               = array_key_exists( 'pgfw_pdf_icon_width', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_pdf_icon_width'] : '';
-	$pgfw_pdf_icon_height              = array_key_exists( 'pgfw_pdf_icon_height', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_pdf_icon_height'] : '';
+	$general_settings_data                   = get_option( 'pgfw_general_settings_save', array() );
+	$pgfw_pdf_generate_mode                  = array_key_exists( 'pgfw_general_pdf_generate_mode', $general_settings_data ) ? $general_settings_data['pgfw_general_pdf_generate_mode'] : '';
+	$mode                                    = ( 'open_window' === $pgfw_pdf_generate_mode ) ? 'target=_blank' : '';
+	$pgfw_display_settings                   = get_option( 'pgfw_save_admin_display_settings', array() );
+	$pgfw_pdf_icon_alignment                 = array_key_exists( 'pgfw_display_pdf_icon_alignment', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_display_pdf_icon_alignment'] : '';
+	$sub_pgfw_pdf_single_download_icon       = array_key_exists( 'sub_pgfw_pdf_single_download_icon', $pgfw_display_settings ) ? $pgfw_display_settings['sub_pgfw_pdf_single_download_icon'] : '';
+	$pgfw_single_pdf_download_icon_src       = ( '' !== $sub_pgfw_pdf_single_download_icon ) ? $sub_pgfw_pdf_single_download_icon : PDF_GENERATOR_FOR_WP_DIR_URL . 'admin/src/images/PDF_Tray.svg';
+	$pgfw_pdf_icon_width                     = array_key_exists( 'pgfw_pdf_icon_width', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_pdf_icon_width'] : '';
+	$pgfw_pdf_icon_height                    = array_key_exists( 'pgfw_pdf_icon_height', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_pdf_icon_height'] : '';
 	$pgfw_body_show_pdf_icon                 = array_key_exists( 'pgfw_body_show_pdf_icon', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_body_show_pdf_icon'] : '';
 	$pgfw_show_post_type_icons_for_user_role = array_key_exists( 'pgfw_show_post_type_icons_for_user_role', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_show_post_type_icons_for_user_role'] : array();
-	$wps_wpg_whatsapp_sharing          = array_key_exists( 'wps_wpg_whatsapp_sharing', $pgfw_display_settings ) ? $pgfw_display_settings['wps_wpg_whatsapp_sharing'] : '';
-	$pgfw_print_enable          = array_key_exists( 'pgfw_print_enable', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_print_enable'] : '';
-	$user = wp_get_current_user();
-	$whatsapp_link = generate_whatsapp_pdf_link( $url_here );
+	$wps_wpg_whatsapp_sharing                = array_key_exists( 'wps_wpg_whatsapp_sharing', $pgfw_display_settings ) ? $pgfw_display_settings['wps_wpg_whatsapp_sharing'] : '';
+	$pgfw_print_enable                       = array_key_exists( 'pgfw_print_enable', $pgfw_display_settings ) ? $pgfw_display_settings['pgfw_print_enable'] : '';
+	$user                                    = wp_get_current_user();
+	$whatsapp_link                           = generate_whatsapp_pdf_link( $url_here );
 
 	if ( is_plugin_active( 'wordpress-pdf-generator/wordpress-pdf-generator.php' ) ) {
-		$wps_wpg_single_pdf_icon_name    = array_key_exists( 'wps_wpg_single_pdf_icon_name', $pgfw_display_settings ) ? $pgfw_display_settings['wps_wpg_single_pdf_icon_name'] : '';
-		$is_pro_active = true;
+		$wps_wpg_single_pdf_icon_name = array_key_exists( 'wps_wpg_single_pdf_icon_name', $pgfw_display_settings ) ? $pgfw_display_settings['wps_wpg_single_pdf_icon_name'] : '';
+		$is_pro_active                = true;
 	} else {
 		$wps_wpg_single_pdf_icon_name = '';
-		$is_pro_active = false;
+		$is_pro_active                = false;
 	}
 
-	if ( 'yes' == $pgfw_body_show_pdf_icon ) {
+	if ( 'yes' === $pgfw_body_show_pdf_icon ) {
 
 		if ( isset( $pgfw_show_post_type_icons_for_user_role ) && ! empty( $pgfw_show_post_type_icons_for_user_role ) && array_intersect( $user->roles, $pgfw_show_post_type_icons_for_user_role ) ) {
 
-			$html  = '<div style="display:flex; gap:10px;justify-content:' . esc_html( $pgfw_pdf_icon_alignment ) . '" class="wps-pgfw-pdf-generate-icon__wrapper-frontend">
+			$html = '<div style="display:flex; gap:10px;justify-content:' . esc_html( $pgfw_pdf_icon_alignment ) . '" class="wps-pgfw-pdf-generate-icon__wrapper-frontend">
 			<div> <a href="' . esc_html( $url_here ) . '" class="pgfw-single-pdf-download-button" ' . esc_html( $mode ) . '><img src="' . esc_url( $pgfw_single_pdf_download_icon_src ) . '" title="' . esc_html__( 'Generate PDF', 'pdf-generator-for-wp' ) . '" style="width:auto; height:' . esc_html( $pgfw_pdf_icon_height ) . 'px;"">' . $wps_wpg_single_pdf_icon_name . '</a>
 			';
-			$html  = apply_filters( 'wps_pgfw_bulk_download_button_filter_hook', $html, $id );
+			$html = apply_filters( 'wps_pgfw_bulk_download_button_filter_hook', $html, $id );
 			if ( $is_pro_active && 'yes' === $pgfw_print_enable ) {
 
 				$html .= '<a href="javascript:void(0)" id="pgfw_print_button" class="pgfw-single-pdf-download-button" ><img  src="' . PDF_GENERATOR_FOR_WP_DIR_URL . 'admin/src/images/print_icon.png" style="display:inline-block;width:auto; height:' . esc_html( $pgfw_pdf_icon_height ) . 'px;" ></a>';
 			}
-			if ( $is_pro_active && 'yes' == $wps_wpg_whatsapp_sharing ) {
+			if ( $is_pro_active && 'yes' === $wps_wpg_whatsapp_sharing ) {
 				$html .= '<a class="pgfw-single-pdf-download-button wps_pgfw_whatsapp_share_icon" href="' . $whatsapp_link . '"><img src="' . PDF_GENERATOR_FOR_WP_DIR_URL . '/admin/src/images/whatsapp.png" style="width:' . esc_html( $pgfw_pdf_icon_width ) . 'px; height:' . esc_html( $pgfw_pdf_icon_height ) . 'px;" ></a>';
 			}
 
@@ -68,15 +68,15 @@ function pgfw_pdf_download_button( $url_here, $id ) {
 			return $html;
 		}
 	} else {
-		$html  = '<div style="display:flex; gap:10px;justify-content:' . esc_html( $pgfw_pdf_icon_alignment ) . '" class="wps-pgfw-pdf-generate-icon__wrapper-frontend">
+		$html = '<div style="display:flex; gap:10px;justify-content:' . esc_html( $pgfw_pdf_icon_alignment ) . '" class="wps-pgfw-pdf-generate-icon__wrapper-frontend">
 		<a  href="' . esc_html( $url_here ) . '" class="pgfw-single-pdf-download-button" ' . esc_html( $mode ) . '><img src="' . esc_url( $pgfw_single_pdf_download_icon_src ) . '" title="' . esc_html__( 'Generate PDF', 'pdf-generator-for-wp' ) . '" style="width:auto; height:' . esc_html( $pgfw_pdf_icon_height ) . 'px;">' . $wps_wpg_single_pdf_icon_name . '</a>
 		';
-		$html  = apply_filters( 'wps_pgfw_bulk_download_button_filter_hook', $html, $id );
+		$html = apply_filters( 'wps_pgfw_bulk_download_button_filter_hook', $html, $id );
 		if ( $is_pro_active && 'yes' === $pgfw_print_enable ) {
 
 			$html .= '<a href="javascript:void(0)" id="pgfw_print_button" class="pgfw-single-pdf-download-button" onclick="window.print()"><img  src="' . PDF_GENERATOR_FOR_WP_DIR_URL . 'admin/src/images/print_icon.png" style="padding-left:10px;display:inline-block;width:auto; height:' . esc_html( $pgfw_pdf_icon_height ) . 'px;" ></a>';
 		}
-		if ( $is_pro_active && 'yes' == $wps_wpg_whatsapp_sharing ) {
+		if ( $is_pro_active && 'yes' === $wps_wpg_whatsapp_sharing ) {
 
 			$html .= '<a class="pgfw-single-pdf-download-button wps_pgfw_whatsapp_share_icon" href="' . $whatsapp_link . '"><img src="' . PDF_GENERATOR_FOR_WP_DIR_URL . '/admin/src/images/whatsapp.png" style="width:auto; height:' . esc_html( $pgfw_pdf_icon_height ) . 'px;" ></a>';
 		}
@@ -92,7 +92,7 @@ function pgfw_pdf_download_button( $url_here, $id ) {
  * @param string $file_url file_url .
  */
 function generate_whatsapp_pdf_link( $file_url ) {
-	$whatsapp_url = 'https://api.whatsapp.com/send?';
+	$whatsapp_url  = 'https://api.whatsapp.com/send?';
 	$whatsapp_url .= 'text=' . urlencode( 'Check out this PDF file: ' . $file_url );
 	return $whatsapp_url;
 }


### PR DESCRIPTION
## Summary

- `phpcbf` auto-fix pass: ~660 formatting/whitespace/alignment/quote-style violations across 29 files.
- ~35 loose comparisons (`==`/`!=`) converted to strict (`===`/`!==`), and a strict-mode flag added to ~20 `in_array()` calls — each verified case-by-case that both operands are always the same type, so behavior is unchanged.
- `urlencode()` → `rawurlencode()` for one call (a tracking number appended to a URL path); left a second `urlencode()` call alone where legacy `+`-for-space form encoding is actually the correct behavior.
- Renamed a `$default` parameter to `$default_value` in a global helper function; confirmed its one call site uses positional args so this is a safe rename.
- Added targeted `phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter` comments (rather than stripping the parameters) for callback signatures required by WordPress/Elementor/REST APIs.

**Deliberately left alone** (owned by sibling PRs, or genuine false positives):
- `WordPress.DB.DirectDatabaseQuery.*` and `sslverify` findings in the admin class and talk-to-expert-form class — owned by the security/PCP PR.
- The `<main><nav><ul>` tab-rendering block in the dashboard template — owned by the fatal-bug-fix PR; phpcbf wanted to reindent it, that was reverted and only safe alignment fixes outside the block were kept.
- The `esc_html()`/`esc_html__()` warning in the embed-source template — owned by the i18n PR.
- All 14 `_register_controls` underscore-prefix warnings across Elementor widgets — required by Elementor's own base-class API; renaming would break the widgets.

## Test Plan

- [x] `php -l` passes on all 30 touched files
- [x] PHPCS violation count: **776 (25 errors, 751 warnings) → 53 (17 errors, 36 warnings)**
- [x] PHPCompatibilityWP (testVersion 7.4-8.3): zero issues on all changed files, matching the pre-existing baseline
- [ ] No manual regression click-through performed — this PR is formatting and comparison-strictness only; each strict-comparison conversion was individually checked for matching operand types rather than blanket-applied

**Note:** this branch was built from the same base as the fatal-bug-fix and security PRs, independently, so it has minor formatting-only overlap with them on shared files (e.g. alignment changes on lines near their logic changes). Recommend merging the fatal-bug-fix and security PRs first, then this one, resolving the small overlap.
